### PR TITLE
Coating protection fb

### DIFF
--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_MirrorTwoCoatingProtection" Id="{e481ed92-d77f-4692-a2ea-e5f1d2863716}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_MirrorTwoCoatingProtection
+VAR_INPUT
+	nCurrentEncoderCount : UDINT; // Current encoder count
+	neVRange : WORD; // Current ev range from stCurrentBeamParams	
+
+	sDevName : STRING := ''; // Device name	
+
+	nUpperCoatingBoundary : UDINT; // Encoder count for upper boundary
+	nUpperCoatingBitmask : WORD; // Bitmask for upper coating
+	sUpperCoatingType : STRING := ''; // Type of coating
+	
+	nLowerCoatingBoundary : UDINT; // Encoder count for lower boundary
+	nLowerCoatingBitMask : WORD;
+	sLowerCoatingType : STRING := ''; // Type of coating
+END_VAR
+VAR_OUTPUT
+END_VAR
+VAR_IN_OUT
+	FFO : FB_HardwareFFOutput;
+END_VAR
+VAR
+	ffUpperCoating: FB_FastFault := (
+		i_xAutoReset := FALSE,
+		i_TypeCode := 16#401);
+	ffLowerCoating : FB_FastFault := (
+		i_xAutoReset := FALSE,
+		i_TypeCode := 16#401);
+		
+	bInit : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF NOT bInit THEN
+	ffUpperCoating.i_Desc := CONCAT(sUpperCoatingType, ' mirror coating incompatible with beam photon energy');
+	ffUpperCoating.i_DevName := sDevName;
+	
+	ffLowerCoating.i_Desc := CONCAT(sLowerCoatingType, ' mirror coating incompatible with beam photon energy');
+	ffLowerCoating.i_DevName := sDevName;
+	
+	bInit := TRUE;
+END_IF
+
+IF nCurrentEncoderCount <= nLowerCoatingBoundary THEN
+	ffLowerCoating.i_xOK := (neVRange AND nLowerCoatingBitMask) = neVRange; 
+	ffUpperCoating.i_xOK  := TRUE;
+ELSIF nCurrentEncoderCount >= nUpperCoatingBoundary THEN
+ 	ffUpperCoating.i_xOK := (neVRange AND nUpperCoatingBitmask) = neVRange;
+	ffLowerCoating.i_xOK := TRUE;
+ELSE
+	ffLowerCoating.i_xOK := FALSE;
+	ffUpperCoating.i_xOK := FALSE;
+END_IF
+
+ffUpperCoating(io_fbFFHWO:=FFO);
+ffLowerCoating(io_fbFFHWO:=FFO);]]></ST>
+    </Implementation>
+    <LineIds Name="FB_MirrorTwoCoatingProtection">
+      <LineId Id="49" Count="0" />
+      <LineId Id="55" Count="5" />
+      <LineId Id="53" Count="1" />
+      <LineId Id="50" Count="0" />
+      <LineId Id="36" Count="11" />
+      <LineId Id="9" Count="0" />
+    </LineIds>
+  </POU>
+</TcPlcObject>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/Version/Global_Version.TcGVL
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_lcls_twincat_optics : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 2, iRevision := 0, sVersion := '0.0.2');
+	stLibVersion_lcls_twincat_optics : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
@@ -61,6 +61,9 @@
     <Compile Include="POUs\FB_RunHOMS.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\Helpers\FB_MirrorTwoCoatingProtection.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="POUs\Helpers\FB_PI_E621_SerialDriver.TcPOU">
       <SubType>Code</SubType>
     </Compile>
@@ -100,6 +103,10 @@
     <PlaceholderReference Include="lcls-twincat-motion">
       <DefaultResolution>lcls-twincat-motion, * (SLAC)</DefaultResolution>
       <Namespace>lcls_twincat_motion</Namespace>
+    </PlaceholderReference>
+    <PlaceholderReference Include="PMPS">
+      <DefaultResolution>PMPS, * (SLAC - LCLS)</DefaultResolution>
+      <Namespace>PMPS</Namespace>
     </PlaceholderReference>
     <PlaceholderReference Include="Tc2_ControllerToolbox">
       <DefaultResolution>Tc2_ControllerToolbox, * (Beckhoff Automation GmbH)</DefaultResolution>
@@ -145,6 +152,9 @@
     </PlaceholderResolution>
     <PlaceholderResolution Include="lcls-twincat-motion">
       <Resolution>lcls-twincat-motion, * (SLAC)</Resolution>
+    </PlaceholderResolution>
+    <PlaceholderResolution Include="PMPS">
+      <Resolution>PMPS, * (SLAC - LCLS)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="TcUnit">
       <Resolution>TcUnit, * (www.tcunit.org)</Resolution>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
@@ -15,9 +15,9 @@
     <LibraryReferences>{180c5325-4437-417e-ad15-a77988b43cc2}</LibraryReferences>
     <CombineIds>false</CombineIds>
     <Company>SLAC</Company>
-    <Released>true</Released>
+    <Released>false</Released>
     <Title>lcls-twincat-optics</Title>
-    <ProjectVersion>0.0.2</ProjectVersion>
+    <ProjectVersion>0.0.0</ProjectVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DUTs\DUT_HOMS.TcDUT">


### PR DESCRIPTION
Generic FB for PMPS fast faults to protect mirror coatings. Two coatings are most common. N coatings some other day.