### PR TITLE
Make 4024.12 compliant

### DIFF
--- a/lcls-twincat-optics/_Config/PLC/lcls_twincat_optics_plc.xti
+++ b/lcls-twincat-optics/_Config/PLC/lcls_twincat_optics_plc.xti
@@ -1,44 +1,22 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNestedPlcProjDef">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12" ClassName="CNestedPlcProjDef">
 	<DataTypes>
 		<DataType>
-			<Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
-			<BitSize>48</BitSize>
-			<BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
-			<ArrayInfo>
-				<LBound>0</LBound>
-				<Elements>6</Elements>
-			</ArrayInfo>
-			<Format>
-				<Printf>%d.%d.%d.%d.%d.%d</Printf>
-				<Parameter>[0]</Parameter>
-				<Parameter>[1]</Parameter>
-				<Parameter>[2]</Parameter>
-				<Parameter>[3]</Parameter>
-				<Parameter>[4]</Parameter>
-				<Parameter>[5]</Parameter>
-			</Format>
-		</DataType>
-		<DataType>
-			<Name GUID="{76D7CEE7-D4AA-4B15-95A1-1448CB4CAD61}" Namespace="lcls_twincat_motion" AutoDeleteType="true">EL5042_Status</Name>
+			<Name GUID="{4B0DBBA4-11EF-DC4A-BF0D-C44F27183D05}" Namespace="lcls_twincat_motion" AutoDeleteType="true">EL5042_Status</Name>
 			<BitSize>0</BitSize>
 			<BaseType GUID="{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}"/>
 			<Hides>
-				<Hide GUID="{DBB5374A-7C6E-4E30-B4C6-4673F508F2FC}"/>
+				<Hide GUID="{76D7CEE7-D4AA-4B15-95A1-1448CB4CAD61}"/>
 			</Hides>
 		</DataType>
 		<DataType>
-			<Name GUID="{5869EE60-6725-4837-96DE-E65F28189E3C}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
-			<Comment>
-				<![CDATA[ Renishaw BiSS-C absolute encoder used with an EL5042]]>
-			</Comment>
+			<Name GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
+			<Comment><![CDATA[ Renishaw BiSS-C absolute encoder used with an EL5042]]></Comment>
 			<BitSize>128</BitSize>
 			<SubItem>
 				<Name>Count</Name>
 				<Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
-				<Comment>
-					<![CDATA[ Connect to encoder "Position" input]]>
-				</Comment>
+				<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 				<BitSize>64</BitSize>
 				<BitOffs>0</BitOffs>
 				<Properties>
@@ -50,28 +28,24 @@
 			</SubItem>
 			<SubItem>
 				<Name>Status</Name>
-				<Type GUID="{76D7CEE7-D4AA-4B15-95A1-1448CB4CAD61}" Namespace="lcls_twincat_motion">EL5042_Status</Type>
-				<Comment>
-					<![CDATA[ Status struct placeholder]]>
-				</Comment>
+				<Type GUID="{4B0DBBA4-11EF-DC4A-BF0D-C44F27183D05}" Namespace="lcls_twincat_motion">EL5042_Status</Type>
+				<Comment><![CDATA[ Status struct placeholder]]></Comment>
 				<BitSize>0</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>Ref</Name>
 				<Type GUID="{18071995-0000-0000-0000-00000000000B}">ULINT</Type>
-				<Comment>
-					<![CDATA[ Encoder zero position (useful for aligned position with gantries)]]>
-				</Comment>
+				<Comment><![CDATA[ Encoder zero position (useful for aligned position with gantries)]]></Comment>
 				<BitSize>64</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
 			<Hides>
-				<Hide GUID="{79F4BF02-4505-4CA4-8C73-2688A5A887F5}"/>
+				<Hide GUID="{5869EE60-6725-4837-96DE-E65F28189E3C}"/>
 			</Hides>
 		</DataType>
 		<DataType>
-			<Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+			<Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>Operational</Name>
@@ -182,6 +156,12 @@
 				<BitOffs>17</BitOffs>
 			</SubItem>
 			<SubItem>
+				<Name>IsDriveLimitActive</Name>
+				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+				<BitSize>1</BitSize>
+				<BitOffs>18</BitOffs>
+			</SubItem>
+			<SubItem>
 				<Name>ContinuousMotion</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
 				<BitSize>1</BitSize>
@@ -268,6 +248,11 @@
 			<Format Name="IEC">
 				<Printf>16#%08X</Printf>
 			</Format>
+			<Relations>
+				<Relation Priority="100">
+					<Type>{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}</Type>
+				</Relation>
+			</Relations>
 		</DataType>
 		<DataType>
 			<Name GUID="{6EF49753-C72C-4F50-AA44-3C7498E76CFE}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_OPMODE</Name>
@@ -463,11 +448,11 @@
 			</ArrayInfo>
 		</DataType>
 		<DataType>
-			<Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+			<Name GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
 			<BitSize>2048</BitSize>
 			<SubItem>
 				<Name>StateDWord</Name>
-				<Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+				<Type GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>0</BitOffs>
 			</SubItem>
@@ -480,8 +465,7 @@
 			<SubItem>
 				<Name>AxisState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Present State Of The Axis Movement (continuous axis):
+				<Comment><![CDATA[Present State Of The Axis Movement (continuous axis):
 0  = INACTIVE:		axis has no job
 1  = RUNNING:		axis is executing a motion job
 2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
@@ -495,8 +479,7 @@ Slaves only:
 External Setpoint Generation:
 41 = EXTSETGEN_MODE1:	external setpoint generation active
 42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
@@ -509,8 +492,7 @@ External Setpoint Generation:
 			<SubItem>
 				<Name>HomingState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Homing Status:
+				<Comment><![CDATA[Axis Homing Status:
 0: idle
 1: start homing
 2: searching home switch
@@ -518,22 +500,19 @@ External Setpoint Generation:
 4: moving off home switch
 5: searching sync pulse
 6: stopping after homing
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>128</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>CoupleState</Name>
 				<Type GUID="{18071995-0000-0000-0000-000000000008}">UDINT</Type>
-				<Comment>
-					<![CDATA[Axis Coupling Status:
+				<Comment><![CDATA[Axis Coupling Status:
 0: axis is a single axis (not coupled)
 1: axis is a master axis
 2: axis is master and slave
 3: axis is a slave axis
-]]>
-				</Comment>
+]]></Comment>
 				<BitSize>32</BitSize>
 				<BitOffs>160</BitOffs>
 			</SubItem>
@@ -722,6 +701,18 @@ External Setpoint Generation:
 				<BitOffs>1600</BitOffs>
 			</SubItem>
 			<SubItem>
+				<Name>AbsPhasingPos</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+				<BitSize>64</BitSize>
+				<BitOffs>1664</BitOffs>
+			</SubItem>
+			<SubItem>
+				<Name>TorqueOffset</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+				<BitSize>64</BitSize>
+				<BitOffs>1728</BitOffs>
+			</SubItem>
+			<SubItem>
 				<Name>ActPosWithoutPosCorrection</Name>
 				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
 				<BitSize>64</BitSize>
@@ -759,13 +750,16 @@ External Setpoint Generation:
 					<Type GUID="{F794B740-82D7-4637-848E-4F74A711D038}">NCAXLESTRUCT_TOPLC4</Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B0-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"/>
+					<Type GUID="{40BD39B2-C3EA-4F74-9F4F-5F1982786F7C}"></Type>
 				</Relation>
 				<Relation Priority="100">
-					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
+					<Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"></Type>
+				</Relation>
+				<Relation Priority="100">
+					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}"></Type>
 				</Relation>
 			</Relations>
 		</DataType>
@@ -955,17 +949,8 @@ External Setpoint Generation:
 			<Vars VarGrpType="1">
 				<Name>PlcTask Inputs</Name>
 				<Var>
-					<Name>LCLS_General.DefaultGlobals.stSys.I_EcatMaster1</Name>
-					<Comment>
-						<![CDATA[ AMS Net ID used for FB_EcatDiag, among others ]]>
-					</Comment>
-					<Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
-				</Var>
-				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.bSTOEnable1</Name>
-					<Comment>
-						<![CDATA[ STO Button]]>
-					</Comment>
+					<Comment><![CDATA[ STO Button]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -974,965 +959,302 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.stYupEnc</Name>
-					<Comment>
-						<![CDATA[ Encoders]]>
-					</Comment>
-					<Type GUID="{5869EE60-6725-4837-96DE-E65F28189E3C}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[ Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[ Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[ Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Comment><![CDATA[ Encoders]]></Comment>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{5869EE60-6725-4837-96DE-E65F28189E3C}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[ Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[ Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[ Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{5869EE60-6725-4837-96DE-E65F28189E3C}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[ Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[ Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[ Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{5869EE60-6725-4837-96DE-E65F28189E3C}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
-					<SubVar>
-						<Name>Count</Name>
-						<Comment>
-							<![CDATA[ Connect to encoder "Position" input]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Status</Name>
-						<Comment>
-							<![CDATA[ Status struct placeholder]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>Ref</Name>
-						<Comment>
-							<![CDATA[ Encoder zero position (useful for aligned position with gantries)]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
-					<Comment>
-						<![CDATA[ Connect to encoder "Position" input]]>
-					</Comment>
+					<Comment><![CDATA[ Connect to encoder "Position" input]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.Axis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.bLimitForwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Forward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.bLimitBackwardEnable</Name>
-					<Comment>
-						<![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC Backward Limit Switch: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.bHome</Name>
-					<Comment>
-						<![CDATA[ NO Home Switch: TRUE if at home]]>
-					</Comment>
+					<Comment><![CDATA[ NO Home Switch: TRUE if at home]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.bHardwareEnable</Name>
-					<Comment>
-						<![CDATA[ NC STO Input: TRUE if ok to move]]>
-					</Comment>
+					<Comment><![CDATA[ NC STO Input: TRUE if ok to move]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.nRawEncoderULINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for ULINT (Biss-C)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for ULINT (Biss-C)]]></Comment>
 					<Type>ULINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.nRawEncoderUINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for UINT (Relative Encoders)]]></Comment>
 					<Type>UINT</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.nRawEncoderINT</Name>
-					<Comment>
-						<![CDATA[ Raw encoder IO for INT (LVDT)]]>
-					</Comment>
+					<Comment><![CDATA[ Raw encoder IO for INT (LVDT)]]></Comment>
 					<Type>INT</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m6.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
-					<SubVar>
-						<Name>AxisState</Name>
-						<Comment>
-							<![CDATA[Present State Of The Axis Movement (continuous axis):
-0  = INACTIVE:		axis has no job
-1  = RUNNING:		axis is executing a motion job
-2  = OVERRIDE_ZERO:	axis is executing a job but override is zero
-3  = PHASE_VELOCONST:	axis is moving at constant velocity
-4  = PHASE_ACCPOS:	axis is accelerating
-5  = PHASE_ACCNEG:	axis is decelerating
-Slaves only:
-11 = PREPHASE:		slave axis is in a motion pre-phase
-12 = SYNCHRONIZING:	slave axis is synchronizing
-13 = SYNCHRONOUS:	slave axis is moving synchronously
-External Setpoint Generation:
-41 = EXTSETGEN_MODE1:	external setpoint generation active
-42 = EXTSETGEN_MODE2:	internal and external setpoint gen. active
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>HomingState</Name>
-						<Comment>
-							<![CDATA[Axis Homing Status:
-0: idle
-1: start homing
-2: searching home switch
-3: stopping on home switch
-4: moving off home switch
-5: searching sync pulse
-6: stopping after homing
-]]>
-						</Comment>
-					</SubVar>
-					<SubVar>
-						<Name>CoupleState</Name>
-						<Comment>
-							<![CDATA[Axis Coupling Status:
-0: axis is a single axis (not coupled)
-1: axis is a master axis
-2: axis is master and slave
-3: axis is a slave axis
-]]>
-						</Comment>
-					</SubVar>
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
-					<Comment>
-						<![CDATA[Raw encoder count]]>
-					</Comment>
+					<Comment><![CDATA[Raw encoder count]]></Comment>
 					<Type>LINT</Type>
 				</Var>
 			</Vars>
-			<Vars VarGrpType="2">
+			<Vars VarGrpType="2" AreaNo="1">
 				<Name>PlcTask Outputs</Name>
 				<Var>
 					<Name>Main.M1.Axis.PlcToNc</Name>
@@ -1940,9 +1262,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M1.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -1951,9 +1271,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M2.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -1962,9 +1280,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M3.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -1973,9 +1289,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M4.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -1984,9 +1298,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M5.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -1995,9 +1307,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M6.bBrakeRelease</Name>
-					<Comment>
-						<![CDATA[ NC Brake Output: TRUE to release brake]]>
-					</Comment>
+					<Comment><![CDATA[ NC Brake Output: TRUE to release brake]]></Comment>
 					<Type>BOOL</Type>
 				</Var>
 				<Var>
@@ -2021,21 +1331,17 @@ External Setpoint Generation:
 					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 			</Vars>
-			<Vars VarGrpType="8">
+			<Vars VarGrpType="8" AreaNo="4">
 				<Name>PlcTask Retains</Name>
 				<Var>
 					<Name>PMPS_GVL.SuccessfulPreemption</Name>
-					<Comment>
-						<![CDATA[ Any time BPTM applies a new BP request which is confirmed]]>
-					</Comment>
+					<Comment><![CDATA[ Any time BPTM applies a new BP request which is confirmed]]></Comment>
 					<Type>UDINT</Type>
 					<InOut>7</InOut>
 				</Var>
 				<Var>
 					<Name>PMPS_GVL.AccumulatedFF</Name>
-					<Comment>
-						<![CDATA[ Any time a FF occurs]]>
-					</Comment>
+					<Comment><![CDATA[ Any time a FF occurs]]></Comment>
 					<Type>UDINT</Type>
 					<InOut>7</InOut>
 				</Var>
@@ -2045,6 +1351,17 @@ External Setpoint Generation:
 					<InOut>7</InOut>
 				</Var>
 			</Vars>
+			<Contexts>
+				<Context>
+					<Id NeedCalleeCall="true">0</Id>
+					<Name>PlcTask</Name>
+					<ManualConfig>
+						<OTCID>#x02010030</OTCID>
+					</ManualConfig>
+					<Priority>20</Priority>
+					<CycleTime>10000000</CycleTime>
+				</Context>
+			</Contexts>
 			<TaskPouOids>
 				<TaskPouOid Prio="20" OTCID="#x08502001"/>
 			</TaskPouOids>

--- a/lcls-twincat-optics/lcls-twincat-optics.tsproj
+++ b/lcls-twincat-optics/lcls-twincat-optics.tsproj
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4022.30">
-	<Project ProjectGUID="{79189941-065E-4A00-8170-A30C306E2106}" TargetNetId="172.21.148.227.1.1" ShowHideConfigurations="#x306">
+<?xml version="1.0"?>
+<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12">
+	<Project ProjectGUID="{79189941-065E-4A00-8170-A30C306E2106}" Target64Bit="true" ShowHideConfigurations="#x306">
 		<System>
 			<Tasks>
 				<Task Id="3" Priority="20" CycleTime="100000" AmsPort="350" AdtTasks="true">

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_PitchControl.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_PitchControl.TcPOU
@@ -1,50 +1,50 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.6">
   <POU Name="FB_PitchControl" Id="{143b5005-3e50-4e14-8a6a-21db919333f0}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_PitchControl
 VAR_IN_OUT
     Pitch : HOMS_PitchMechanism;
-	Stepper : DUT_MotionStage;
+    Stepper : DUT_MotionStage;
 END_VAR
 VAR_INPUT
-	lrCurrentSetpoint : LREAL; // Setpoint: Epics writes to DUT_MotionStage which gets fed into this
+    lrCurrentSetpoint : LREAL; // Setpoint: Epics writes to DUT_MotionStage which gets fed into this
 END_VAR
 VAR_OUTPUT
-	q_bError : BOOL;
-	q_bDone : BOOL;
-	q_bBusy : BOOL;
+    q_bError : BOOL;
+    q_bDone : BOOL;
+    q_bBusy : BOOL;
 END_VAR
 VAR
-	// Logging
-	stDiag : ST_fbDiagnostics;
-	fbFormatString : FB_FormatString;
-	{attribute 'instance-path'}
-	{attribute 'no_init'}
-	POUName : STRING; // Name of the POU for logging/error reporting
+    // Logging
+    stDiag : ST_fbDiagnostics;
+    fbFormatString : FB_FormatString;
+    {attribute 'instance-path'}
+    {attribute 'no_init'}
+    POUName : T_MaxString; // Name of the POU for logging/error reporting
 
-	// Stepper Motion
+    // Stepper Motion
     lrActPos : LREAL; // Actual Position of piezo mechanism
-	lrPrevStepperPos : LREAL; // Previous successfully achieved stepper position
-	ftLimitSwitch : F_TRIG;
-	lrOriginalPosRequest : LREAL; // Used for logging
-	lrLastSetpoint : LREAL; // Previous successfully achieved setpoint
-	fbMotionRequest : FB_MotionRequest;
-	fbMotionStage : FB_MotionStage;
-	bLimitHit : BOOL;
-	tonStepperHold : TON := (PT:=T#100MS); // Timer to hold stepper position while the system relaxes
-	rSettledRange : REAL := 5.0; // Units = urad
-	bResetStepper : BOOL;
-	bExecuteStepper : BOOL;
-	enumMotionRequest : ENUM_MotionRequest := ENUM_MotionRequest.WAIT; // Wait for move to complete before taking another request
+    lrPrevStepperPos : LREAL; // Previous successfully achieved stepper position
+    ftLimitSwitch : F_TRIG;
+    lrOriginalPosRequest : LREAL; // Used for logging
+    lrLastSetpoint : LREAL; // Previous successfully achieved setpoint
+    fbMotionRequest : FB_MotionRequest;
+    fbMotionStage : FB_MotionStage;
+    bLimitHit : BOOL;
+    tonStepperHold : TON := (PT:=T#100MS); // Timer to hold stepper position while the system relaxes
+    rSettledRange : REAL := 5.0; // Units = urad
+    bResetStepper : BOOL;
+    bExecuteStepper : BOOL;
+    enumMotionRequest : ENUM_MotionRequest := ENUM_MotionRequest.WAIT; // Wait for move to complete before taking another request
 
-	// Piezo
-	tonPiezoSettled : TON := (PT:=T#2S);
-	fbPiezoControl : FB_PiezoControl;
-	rtPiezoMoveDone : R_TRIG;
+    // Piezo
+    tonPiezoSettled : TON := (PT:=T#2S);
+    fbPiezoControl : FB_PiezoControl;
+    rtPiezoMoveDone : R_TRIG;
 
-	// State Machine
-	PC_State : E_PitchControl := PCM_Init;
-	bCoarse50PiezoMove : BOOL;
+    // State Machine
+    PC_State : E_PitchControl := PCM_Init;
+    bCoarse50PiezoMove : BOOL;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[(* HOMS Pitch Control
@@ -57,9 +57,9 @@ the pitch of the mirror assembly.
 Pitch control state machine
 
 If the target position is beyond the range of the piezo mechanism,
-execute a coarse pitch move with the stepper. 
-The target of the coarse move shall be set to the requested position. 
-Once coarse motion has completed the coarse motion drive position 
+execute a coarse pitch move with the stepper.
+The target of the coarse move shall be set to the requested position.
+Once coarse motion has completed the coarse motion drive position
 correction output shall be set to zero.
 
 Fine pitch motion with the piezo will be initiated to finish closing the loop.
@@ -72,115 +72,115 @@ lrActPos := Stepper.stAxisStatus.fActPosition;
 // If we hit a limit during a move, we need to change the setpoint
 ftLimitSwitch(CLK:=Stepper.bAllForwardEnable AND Stepper.bAllBackwardEnable);
 IF ftLimitSwitch.Q THEN
-	bExecuteStepper := FALSE;
-	bLimitHit := TRUE;
-	lrCurrentSetpoint := lrActPos;
+    bExecuteStepper := FALSE;
+    bLimitHit := TRUE;
+    lrCurrentSetpoint := lrActPos;
 END_IF
 
 // Left out Manual Mode Switch and Tweak FBs
 
 // State Machine
 CASE PC_State OF
-	PCM_Init:
-		lrCurrentSetpoint := lrActPos;
-		lrLastSetpoint := lrCurrentSetpoint;
-		lrPrevStepperPos := lrCurrentSetpoint;
-		PC_State := PCM_Standby;
-	PCM_Standby:
-		// Waits for move requests and determines if they are valid
-		IF (lrLastSetpoint <> lrCurrentSetpoint) THEN // lrLastSetpoint initially set in PCM_Done
-			// Check for bad setpoints -> revert to previous setpoint
-			IF 	(lrCurrentSetpoint > Pitch.ReqPosLimHi) OR (lrCurrentSetpoint < Pitch.ReqPosLimLo) OR NOT Stepper.bHardwareEnable THEN
-				// Outside range of limit switches or bHardwareEnable is FALSE
-				ACT_ResetSetpoint();
-			ELSIF lrCurrentSetpoint > lrLastSetpoint AND NOT Stepper.bAllForwardEnable THEN
-				// Forward move when on HL
-				ACT_ResetSetpoint();
-			ELSIF lrCurrentSetpoint < lrLastSetpoint AND NOT Stepper.bAllBackwardEnable THEN
-				// Backward move when on LL
-				ACT_ResetSetpoint();
-			END_IF
-			// If the current setpoint still differs from the prvious, we know the move is safe and OK to proceed
-			IF lrLastSetpoint <> lrCurrentSetpoint THEN
-				q_bDone := FALSE;
-				PC_State := PCM_MoveRequested;
-			END_IF
-		END_IF
-	PCM_MoveRequested:
-		// A move has been requested, is it within range of the piezo?
-		IF WithinRange(ValA:=lrCurrentSetpoint, Center:=lrPrevStepperPos, Range:=GVL_Constants.cPiezoRange, Offset:=0) THEN
-			// Move is within the nominal range of the piezo
-			fbFormatString.sFormat := 'Within range, fine move %f';
-			fbFormatString.arg1 := F_LREAL(lrCurrentSetpoint);
-			fbFormatString(sOut=>stDiag.asResults[stDiag.resultIdx.IncVal()]);
-			PC_State := PCM_FineMove;
-		ELSE
-			// Out of range, head to coarse move
-			fbFormatString.arg1 := F_LREAL(lrCurrentSetpoint);
-			fbFormatString.sFormat := 'OoR, using stepper %f';
-			fbFormatString(sOut=>stDiag.asResults[stDiag.resultIdx.IncVal()]);
-			PC_State := PCM_Coarse50Piezo;
-		END_IF
-	PCM_Coarse50Piezo:
-		// A coarse move uses the stepper to do a best-effort position
-		// First set the piezo to nominal 50% extension using idle mode
-		//////////////////////////////////////////////////////////////////////////////
-		Pitch.Piezo.xIdleMode := TRUE;
-		// Indicate we are doing the coarse 50% piezo move	
-		bCoarse50PiezoMove := TRUE;
-		// Wait for piezo to settle
-		tonPiezoSettled.IN := TRUE;
-		bCoarse50PiezoMove R= tonPiezoSettled.Q;
-		IF tonPiezoSettled.Q THEN
-			//Piezo has moved to 50% position, finish with the stepper
-			PC_State := PCM_CoarseMove;
-			tonPiezoSettled.IN := FALSE;
-		END_IF
-	PCM_CoarseMove: 
-		// With the piezo at a nominal 50% extension, move the stepper to requested position
-		bExecuteStepper := TRUE;
-		// Timer that waits to start until stepper is within range of the setpoint
-		tonStepperHold.IN := WithinRange(ValA:=LREAL_TO_REAL(lrActPos), Center:=lrCurrentSetpoint, Range:=rSettledRange, Offset:=0);
-		tonStepperHold(); // call this here to reset Q just below on first cycle
-		// If the coarse move is complete, finish position correction with the piezo
-		IF tonStepperHold.Q  OR ftLimitSwitch.Q THEN
-			PC_State := PCM_CoarseMoveCleanup;
-			lrPrevStepperPos := lrActPos;
-		ELSIF Stepper.bError THEN
-			bExecuteStepper := FALSE;
-			PC_State := PCM_StepperError;
-			// Left out logging
-		END_IF
-	PCM_CoarseMoveCleanup:
-		bExecuteStepper := FALSE;
-		PC_State := PCM_FineMove;
-	PCM_FineMove:	
-		Pitch.Piezo.xIdleMode := FALSE;
-		fbPiezoControl.xExecute := TRUE;
-		IF bLimitHit THEN
-			Pitch.Piezo.rReqAbsPos := lrActPos;
-		ELSE
-			Pitch.Piezo.rReqAbsPos := lrCurrentSetpoint;
-		END_IF
-		rtPiezoMoveDone(CLK:=fbPiezoControl.xDone);
-		IF rtPiezoMoveDone.Q THEN
-			fbPiezoControl.xExecute := FALSE;
-			PC_State := PCM_Done;
-		END_IF
-	PCM_Done:
-		// Set the previously requested position here
-		lrLastSetpoint := lrCurrentSetpoint;
-		bLimitHit := FALSE;
-		// Indicate we're done
-		q_bDone	:= TRUE;
-		// Move back to standby
-		PC_State := PCM_Standby;
-	PCM_StepperError:
-		PC_State := PCM_Init;
-	PCM_PiezoError:
-		PC_State := PCM_Init;
-	PCM_OtherError:
-		PC_State := PCM_Init;
+    PCM_Init:
+        lrCurrentSetpoint := lrActPos;
+        lrLastSetpoint := lrCurrentSetpoint;
+        lrPrevStepperPos := lrCurrentSetpoint;
+        PC_State := PCM_Standby;
+    PCM_Standby:
+        // Waits for move requests and determines if they are valid
+        IF (lrLastSetpoint <> lrCurrentSetpoint) THEN // lrLastSetpoint initially set in PCM_Done
+            // Check for bad setpoints -> revert to previous setpoint
+            IF 	(lrCurrentSetpoint > Pitch.ReqPosLimHi) OR (lrCurrentSetpoint < Pitch.ReqPosLimLo) OR NOT Stepper.bHardwareEnable THEN
+                // Outside range of limit switches or bHardwareEnable is FALSE
+                ACT_ResetSetpoint();
+            ELSIF lrCurrentSetpoint > lrLastSetpoint AND NOT Stepper.bAllForwardEnable THEN
+                // Forward move when on HL
+                ACT_ResetSetpoint();
+            ELSIF lrCurrentSetpoint < lrLastSetpoint AND NOT Stepper.bAllBackwardEnable THEN
+                // Backward move when on LL
+                ACT_ResetSetpoint();
+            END_IF
+            // If the current setpoint still differs from the prvious, we know the move is safe and OK to proceed
+            IF lrLastSetpoint <> lrCurrentSetpoint THEN
+                q_bDone := FALSE;
+                PC_State := PCM_MoveRequested;
+            END_IF
+        END_IF
+    PCM_MoveRequested:
+        // A move has been requested, is it within range of the piezo?
+        IF WithinRange(ValA:=lrCurrentSetpoint, Center:=lrPrevStepperPos, Range:=GVL_Constants.cPiezoRange, Offset:=0) THEN
+            // Move is within the nominal range of the piezo
+            fbFormatString.sFormat := 'Within range, fine move %f';
+            fbFormatString.arg1 := F_LREAL(lrCurrentSetpoint);
+            fbFormatString(sOut=>stDiag.asResults[stDiag.resultIdx.IncVal()]);
+            PC_State := PCM_FineMove;
+        ELSE
+            // Out of range, head to coarse move
+            fbFormatString.arg1 := F_LREAL(lrCurrentSetpoint);
+            fbFormatString.sFormat := 'OoR, using stepper %f';
+            fbFormatString(sOut=>stDiag.asResults[stDiag.resultIdx.IncVal()]);
+            PC_State := PCM_Coarse50Piezo;
+        END_IF
+    PCM_Coarse50Piezo:
+        // A coarse move uses the stepper to do a best-effort position
+        // First set the piezo to nominal 50% extension using idle mode
+        //////////////////////////////////////////////////////////////////////////////
+        Pitch.Piezo.xIdleMode := TRUE;
+        // Indicate we are doing the coarse 50% piezo move
+        bCoarse50PiezoMove := TRUE;
+        // Wait for piezo to settle
+        tonPiezoSettled.IN := TRUE;
+        bCoarse50PiezoMove R= tonPiezoSettled.Q;
+        IF tonPiezoSettled.Q THEN
+            //Piezo has moved to 50% position, finish with the stepper
+            PC_State := PCM_CoarseMove;
+            tonPiezoSettled.IN := FALSE;
+        END_IF
+    PCM_CoarseMove:
+        // With the piezo at a nominal 50% extension, move the stepper to requested position
+        bExecuteStepper := TRUE;
+        // Timer that waits to start until stepper is within range of the setpoint
+        tonStepperHold.IN := WithinRange(ValA:=LREAL_TO_REAL(lrActPos), Center:=lrCurrentSetpoint, Range:=rSettledRange, Offset:=0);
+        tonStepperHold(); // call this here to reset Q just below on first cycle
+        // If the coarse move is complete, finish position correction with the piezo
+        IF tonStepperHold.Q  OR ftLimitSwitch.Q THEN
+            PC_State := PCM_CoarseMoveCleanup;
+            lrPrevStepperPos := lrActPos;
+        ELSIF Stepper.bError THEN
+            bExecuteStepper := FALSE;
+            PC_State := PCM_StepperError;
+            // Left out logging
+        END_IF
+    PCM_CoarseMoveCleanup:
+        bExecuteStepper := FALSE;
+        PC_State := PCM_FineMove;
+    PCM_FineMove:
+        Pitch.Piezo.xIdleMode := FALSE;
+        fbPiezoControl.xExecute := TRUE;
+        IF bLimitHit THEN
+            Pitch.Piezo.rReqAbsPos := lrActPos;
+        ELSE
+            Pitch.Piezo.rReqAbsPos := lrCurrentSetpoint;
+        END_IF
+        rtPiezoMoveDone(CLK:=fbPiezoControl.xDone);
+        IF rtPiezoMoveDone.Q THEN
+            fbPiezoControl.xExecute := FALSE;
+            PC_State := PCM_Done;
+        END_IF
+    PCM_Done:
+        // Set the previously requested position here
+        lrLastSetpoint := lrCurrentSetpoint;
+        bLimitHit := FALSE;
+        // Indicate we're done
+        q_bDone	:= TRUE;
+        // Move back to standby
+        PC_State := PCM_Standby;
+    PCM_StepperError:
+        PC_State := PCM_Init;
+    PCM_PiezoError:
+        PC_State := PCM_Init;
+    PCM_OtherError:
+        PC_State := PCM_Init;
 END_CASE
 
 fbMotionStage(stMotionStage:=Stepper);
@@ -191,8 +191,8 @@ Pitch.Piezo.rActPos := lrActPos;
 tonPiezoSettled();
 tonStepperHold();
 fbPiezoControl(iq_Piezo:=Pitch.Piezo,
-	           Enable_Positive:=Stepper.bLimitForwardEnable,
-			   Enable_Negative:=Stepper.bLimitBackwardEnable);]]></ST>
+               Enable_Positive:=Stepper.bLimitForwardEnable,
+               Enable_Negative:=Stepper.bLimitBackwardEnable);]]></ST>
     </Implementation>
     <Action Name="ACT_ResetSetpoint" Id="{0b95a558-7e3a-4f95-aac8-420be385c984}">
       <Implementation>
@@ -205,12 +205,12 @@ lrOriginalPosRequest := lrCurrentSetpoint;
 lrCurrentSetpoint := lrLastSetpoint;
 // Only want to log one warning about a bad position request
 IF lrOriginalPosRequest <> lrCurrentSetpoint THEN
-	// Log a warning
-	fbFormatString.sFormat := 'Pitch req OoR fb (%s), reset within limits, %f';
-	fbFormatString.arg1 := F_STRING(POUName);
-	fbFormatString.arg2 := F_LREAL(lrOriginalPosRequest);
-	fbFormatString(sOut=>stDiag.asResults[stDiag.resultIdx.IncVal()]);
-	PC_State := PCM_Standby;
+    // Log a warning
+    fbFormatString.sFormat := 'Pitch req OoR fb (%s), reset within limits, %f';
+    fbFormatString.arg1 := F_STRING(POUName);
+    fbFormatString.arg2 := F_LREAL(lrOriginalPosRequest);
+    fbFormatString(sOut=>stDiag.asResults[stDiag.resultIdx.IncVal()]);
+    PC_State := PCM_Standby;
 END_IF]]></ST>
       </Implementation>
     </Action>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_PI_E621_SerialDriver.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_PI_E621_SerialDriver.TcPOU
@@ -1,41 +1,41 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.6">
   <POU Name="FB_PI_E621_SerialDriver" Id="{70cebafc-4342-47f0-b840-ef59112aefde}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_PI_E621_SerialDriver
 VAR_INPUT
-	/// rising edge execute 
-	i_xExecute: BOOL;
-	/// Maximum wait time for reply 
-	i_tTimeOut: TIME := TIME#1S0MS;
+    /// rising edge execute
+    i_xExecute: BOOL;
+    /// Maximum wait time for reply
+    i_tTimeOut: TIME := TIME#1S0MS;
 //	i_xReset : BOOL := FALSE; //reset function, for timeout etc
 END_VAR
 VAR_OUTPUT
-	q_xDone: BOOL;
-	q_xError: BOOL;
-	q_sResult: STRING(255);
-	/// Last Strings Sent to Serial Device - for debugging 
-	q_asLastSentStrings: ARRAY[1..50] OF STRING;
-	/// Last Strings Received from Serial Device - for debugging 
-	q_asLastReceivedStrings: ARRAY[1..50] OF STRING;
+    q_xDone: BOOL;
+    q_xError: BOOL;
+    q_sResult: T_MaxString;
+    /// Last Strings Sent to Serial Device - for debugging
+    q_asLastSentStrings: ARRAY[1..50] OF STRING;
+    /// Last Strings Received from Serial Device - for debugging
+    q_asLastReceivedStrings: ARRAY[1..50] OF STRING;
 END_VAR
 VAR_IN_OUT
-	iq_stPiezoAxis	:	ST_PiezoAxis;
-	iq_stSerialRXBuffer: ComBuffer;
-	iq_stSerialTXBuffer: ComBuffer;
+    iq_stPiezoAxis	:	ST_PiezoAxis;
+    iq_stSerialRXBuffer: ComBuffer;
+    iq_stSerialTXBuffer: ComBuffer;
 END_VAR
 VAR
-	rtExecute		: R_TRIG;
-	rtTransDone		: R_TRIG;
-	iStep: INT;
-	sSendData: STRING;
-	fbPITransaction: FB_PI_E621_SerialTransaction;
-	fbFormatString: FB_FormatString;
-	sErrMesg : STRING := 'In step %d fbPITransaction failed with message: %s';
-	i		: INT := 1;
+    rtExecute		: R_TRIG;
+    rtTransDone		: R_TRIG;
+    iStep: INT;
+    sSendData: STRING;
+    fbPITransaction: FB_PI_E621_SerialTransaction;
+    fbFormatString: FB_FormatString;
+    sErrMesg : STRING := 'In step %d fbPITransaction failed with message: %s';
+    i		: INT := 1;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[(* S. Stubbs, 2-23-2017 *)
-(* This function block drives serial communication with a PI E-816 or compatible comm module. 
+(* This function block drives serial communication with a PI E-816 or compatible comm module.
    Note this needs to be re-jiggered if the E-517 is used, uses number rather than letter for axis *)
 
 (* RS232 default settings: 115200 8N1, RTS/CTS
@@ -49,156 +49,156 @@ Not all commands use axis and parameter, for example ERR?
 (* rising edge trigger *)
 rtExecute(CLK:= i_xExecute);
 IF rtExecute.Q THEN
-	q_xDone	:= FALSE;
-	q_xError := FALSE;
-	q_sResult:= '';
-	iq_stPiezoAxis.xDriverError := FALSE;
+    q_xDone	:= FALSE;
+    q_xError := FALSE;
+    q_sResult:= '';
+    iq_stPiezoAxis.xDriverError := FALSE;
 //	i_xReset := FALSE;
-	a_ClearTrans();  (* to provide rising edge for execute *)
-	IF iq_stPiezoAxis.sIdn= '' THEN (* Should only need to check identity once *)
-		iStep := 5;
-	ELSE
-		iStep := 10;
-	END_IF
+    a_ClearTrans();  (* to provide rising edge for execute *)
+    IF iq_stPiezoAxis.sIdn= '' THEN (* Should only need to check identity once *)
+        iStep := 5;
+    ELSE
+        iStep := 10;
+    END_IF
 END_IF
 
 
 CASE iStep OF
-	0: (* idle *)
-		;
+    0: (* idle *)
+        ;
 
-	(* Commands *)
-	5: (* Get Identity *)
-			fbPITransaction.i_xExecute:= TRUE;
-			fbPITransaction.i_sCmd:= '*IDN?';
-		IF fbPITransaction.q_xDone THEN
-				iq_stPiezoAxis.sIdn := fbPITransaction.q_sResponseData; //Hello I am a piezo
-				a_ClearTrans();  (* to provide rising edge for execute *)
-				iStep := 10;
-		ELSIF fbPITransaction.q_xError THEN
-			a_ErrorMesg();
-			iStep := 9000;
-		END_IF
-		
-	10: (* Check Servo Mode 
-		To use manual voltage servo mode must be off *)
-		(* Response: 0$L or 1$L *)
-		fbPITransaction.i_xExecute:= TRUE;
-		fbPITransaction.i_sCmd:= 'SVO?';
-		fbPITransaction.i_sAxis:= iq_stPiezoAxis.sAxis;
-		IF fbPITransaction.q_xDone THEN
-			IF FIND('1',fbPITransaction.q_sResponseData) <> 0 THEN //Iff in servo mode, turn it off
-				a_ClearTrans();  (* to provide rising edge for execute *)
-				iStep := iStep + 10;
-			ELSE 
-				a_ClearTrans();
-				iStep := iStep + 20;  //Skip setting servo mode
-			END_IF
-		ELSIF fbPITransaction.q_xError THEN
-			a_ErrorMesg();
-			iStep := 9000;
-		END_IF
+    (* Commands *)
+    5: (* Get Identity *)
+            fbPITransaction.i_xExecute:= TRUE;
+            fbPITransaction.i_sCmd:= '*IDN?';
+        IF fbPITransaction.q_xDone THEN
+                iq_stPiezoAxis.sIdn := fbPITransaction.q_sResponseData; //Hello I am a piezo
+                a_ClearTrans();  (* to provide rising edge for execute *)
+                iStep := 10;
+        ELSIF fbPITransaction.q_xError THEN
+            a_ErrorMesg();
+            iStep := 9000;
+        END_IF
 
-	20: (* Set Servo Mode *)
-		fbPITransaction.i_xExecute:= TRUE;
-		fbPITransaction.i_sCmd:= 'SVO';
-		fbPITransaction.i_sAxis:= iq_stPiezoAxis.sAxis;
-		fbPITransaction.i_sParam:= '0';
-		fbPITransaction.i_xExpectReply:= FALSE;
-		IF fbPITransaction.q_xDone THEN
-			a_ClearTrans();  (* to provide rising edge for execute *)
-			iStep := iStep + 10;
-		ELSIF fbPITransaction.q_xError THEN
-			a_ErrorMesg();
-			iStep := 9000;
-		END_IF
-		
-	30: (* Set Voltage, only if needed *)
-		IF iq_stPiezoAxis.rSetVoltage <> iq_stPiezoAxis.rLastReqVoltage THEN
-			fbPITransaction.i_xExecute:= TRUE;
-			fbPITransaction.i_sCmd:= 'SVA';
-			fbPITransaction.i_sAxis:= iq_stPiezoAxis.sAxis;
-			fbPITransaction.i_sParam:=REAL_TO_STRING(iq_stPiezoAxis.rSetVoltage);
-			fbPITransaction.i_xExpectReply:= FALSE;
-			IF fbPITransaction.q_xDone THEN
-					a_ClearTrans();  (* to provide rising edge for execute *)
-					iStep := iStep + 10;
-			ELSIF fbPITransaction.q_xError THEN
-				a_ErrorMesg();
-				iStep := 9000;
-			END_IF
-		ELSE
-			iStep := iStep + 30; //Should only need to check error and setpoint if setting voltage
-		END_IF
+    10: (* Check Servo Mode
+        To use manual voltage servo mode must be off *)
+        (* Response: 0$L or 1$L *)
+        fbPITransaction.i_xExecute:= TRUE;
+        fbPITransaction.i_sCmd:= 'SVO?';
+        fbPITransaction.i_sAxis:= iq_stPiezoAxis.sAxis;
+        IF fbPITransaction.q_xDone THEN
+            IF FIND('1',fbPITransaction.q_sResponseData) <> 0 THEN //Iff in servo mode, turn it off
+                a_ClearTrans();  (* to provide rising edge for execute *)
+                iStep := iStep + 10;
+            ELSE
+                a_ClearTrans();
+                iStep := iStep + 20;  //Skip setting servo mode
+            END_IF
+        ELSIF fbPITransaction.q_xError THEN
+            a_ErrorMesg();
+            iStep := 9000;
+        END_IF
 
-	40: (* Get Error Code, also resets current error *)
-	(* Response: integer error code *)
-			fbPITransaction.i_xExecute:= TRUE;
-			fbPITransaction.i_sCmd:= 'ERR?';
-		IF fbPITransaction.q_xDone THEN
-				iq_stPiezoAxis.iCurError := STRING_TO_INT(fbPITransaction.q_sResponseData);
-				IF iq_stPiezoAxis.iCurError <> 0 THEN
-					iq_stPiezoAxis.iLastError:= iq_stPiezoAxis.iCurError;
-				END_IF
-				a_ClearTrans();  (* to provide rising edge for execute *)
-				iStep := iStep + 10;
-		ELSIF fbPITransaction.q_xError THEN
-			a_ErrorMesg();
-			iStep := 9000;
-		END_IF
+    20: (* Set Servo Mode *)
+        fbPITransaction.i_xExecute:= TRUE;
+        fbPITransaction.i_sCmd:= 'SVO';
+        fbPITransaction.i_sAxis:= iq_stPiezoAxis.sAxis;
+        fbPITransaction.i_sParam:= '0';
+        fbPITransaction.i_xExpectReply:= FALSE;
+        IF fbPITransaction.q_xDone THEN
+            a_ClearTrans();  (* to provide rising edge for execute *)
+            iStep := iStep + 10;
+        ELSIF fbPITransaction.q_xError THEN
+            a_ErrorMesg();
+            iStep := 9000;
+        END_IF
 
-	50: (* Get Last Requested Piezo Voltage *)
-	(* Response: (float)$L *)
-			fbPITransaction.i_xExecute:= TRUE;
-			fbPITransaction.i_sCmd:= 'SVA?';
-			fbPITransaction.i_sAxis:= iq_stPiezoAxis.sAxis;
-		IF fbPITransaction.q_xDone THEN
-			iq_stPiezoAxis.rLastReqVoltage := STRING_TO_REAL(fbPITransaction.q_sResponseData);
-			//Check and reset attempts if it went through
-			a_ClearTrans();  (* to provide rising edge for execute *)
-			iStep := iStep + 10;
-		ELSIF fbPITransaction.q_xError THEN
-			a_ErrorMesg();
-			iStep := 9000;
-		END_IF
-		
-	60: (* Get Actual Piezo Voltage *)
-	(* Response: (float)$L *)
-			fbPITransaction.i_xExecute:= TRUE;
-			fbPITransaction.i_sCmd:= 'VOL?';
-			// E-517 works differently, uses number rather than letter for axis
-			fbPITransaction.i_sAxis:= iq_stPiezoAxis.sAxis;
-		IF fbPITransaction.q_xDone THEN
-				iq_stPiezoAxis.rActVoltage := STRING_TO_REAL(fbPITransaction.q_sResponseData);
-				a_ClearTrans();  (* to provide rising edge for execute *)
-				iStep := 8000; (* Done *)
-		ELSIF fbPITransaction.q_xError THEN
-			a_ErrorMesg();
-			iStep := 9000;
-		END_IF
-		
-	8000: (* done *)
-		q_xDone := TRUE;
-		IF  i_xExecute = FALSE THEN
-			q_xDone:= FALSE;
-			iStep := 0;
-		END_IF
+    30: (* Set Voltage, only if needed *)
+        IF iq_stPiezoAxis.rSetVoltage <> iq_stPiezoAxis.rLastReqVoltage THEN
+            fbPITransaction.i_xExecute:= TRUE;
+            fbPITransaction.i_sCmd:= 'SVA';
+            fbPITransaction.i_sAxis:= iq_stPiezoAxis.sAxis;
+            fbPITransaction.i_sParam:=REAL_TO_STRING(iq_stPiezoAxis.rSetVoltage);
+            fbPITransaction.i_xExpectReply:= FALSE;
+            IF fbPITransaction.q_xDone THEN
+                    a_ClearTrans();  (* to provide rising edge for execute *)
+                    iStep := iStep + 10;
+            ELSIF fbPITransaction.q_xError THEN
+                a_ErrorMesg();
+                iStep := 9000;
+            END_IF
+        ELSE
+            iStep := iStep + 30; //Should only need to check error and setpoint if setting voltage
+        END_IF
 
-	9000: (* Error *)
-		a_ClearTrans();  (* to provide rising edge for execute *)
-		IF fbPITransaction.q_xTimeout THEN
-			iStep:=10;//start over
-		ELSE
-		q_xError := TRUE;
-		iq_stPiezoAxis.xDriverError := TRUE;
-		END_IF	
+    40: (* Get Error Code, also resets current error *)
+    (* Response: integer error code *)
+            fbPITransaction.i_xExecute:= TRUE;
+            fbPITransaction.i_sCmd:= 'ERR?';
+        IF fbPITransaction.q_xDone THEN
+                iq_stPiezoAxis.iCurError := STRING_TO_INT(fbPITransaction.q_sResponseData);
+                IF iq_stPiezoAxis.iCurError <> 0 THEN
+                    iq_stPiezoAxis.iLastError:= iq_stPiezoAxis.iCurError;
+                END_IF
+                a_ClearTrans();  (* to provide rising edge for execute *)
+                iStep := iStep + 10;
+        ELSIF fbPITransaction.q_xError THEN
+            a_ErrorMesg();
+            iStep := 9000;
+        END_IF
+
+    50: (* Get Last Requested Piezo Voltage *)
+    (* Response: (float)$L *)
+            fbPITransaction.i_xExecute:= TRUE;
+            fbPITransaction.i_sCmd:= 'SVA?';
+            fbPITransaction.i_sAxis:= iq_stPiezoAxis.sAxis;
+        IF fbPITransaction.q_xDone THEN
+            iq_stPiezoAxis.rLastReqVoltage := STRING_TO_REAL(fbPITransaction.q_sResponseData);
+            //Check and reset attempts if it went through
+            a_ClearTrans();  (* to provide rising edge for execute *)
+            iStep := iStep + 10;
+        ELSIF fbPITransaction.q_xError THEN
+            a_ErrorMesg();
+            iStep := 9000;
+        END_IF
+
+    60: (* Get Actual Piezo Voltage *)
+    (* Response: (float)$L *)
+            fbPITransaction.i_xExecute:= TRUE;
+            fbPITransaction.i_sCmd:= 'VOL?';
+            // E-517 works differently, uses number rather than letter for axis
+            fbPITransaction.i_sAxis:= iq_stPiezoAxis.sAxis;
+        IF fbPITransaction.q_xDone THEN
+                iq_stPiezoAxis.rActVoltage := STRING_TO_REAL(fbPITransaction.q_sResponseData);
+                a_ClearTrans();  (* to provide rising edge for execute *)
+                iStep := 8000; (* Done *)
+        ELSIF fbPITransaction.q_xError THEN
+            a_ErrorMesg();
+            iStep := 9000;
+        END_IF
+
+    8000: (* done *)
+        q_xDone := TRUE;
+        IF  i_xExecute = FALSE THEN
+            q_xDone:= FALSE;
+            iStep := 0;
+        END_IF
+
+    9000: (* Error *)
+        a_ClearTrans();  (* to provide rising edge for execute *)
+        IF fbPITransaction.q_xTimeout THEN
+            iStep:=10;//start over
+        ELSE
+        q_xError := TRUE;
+        iq_stPiezoAxis.xDriverError := TRUE;
+        END_IF
 
 END_CASE
 
 //call transaction
 fbPITransaction(
-	iq_stSerialRXBuffer:= iq_stSerialRXBuffer, 
-	iq_stSerialTXBuffer:= iq_stSerialTXBuffer);
+    iq_stSerialRXBuffer:= iq_stSerialRXBuffer,
+    iq_stSerialTXBuffer:= iq_stSerialTXBuffer);
 
 iq_stPiezoAxis.xTimeout:=fbPITransaction.q_xTimeout;
 (* Rising edge trigger to take care of debugging history *)
@@ -206,7 +206,7 @@ rtTransDone(CLK:= fbPITransaction.q_xDone);
 IF rtTransDone.Q THEN
 q_asLastSentStrings[i] := fbPITransaction.q_sLastSentString;
 q_asLastReceivedStrings[i] := fbPITransaction.q_sLastReceivedString;
-i := i + 1; 
+i := i + 1;
 END_IF
 IF i = 51 THEN i := 1; END_IF]]></ST>
     </Implementation>
@@ -218,34 +218,34 @@ fbPITransaction.i_sCmd:= ''; //Input args are Cmd, Axis and Param
 fbPITransaction.i_sAxis:= '';
 fbPITransaction.i_sParam:= '';
 fbPITransaction(
-	i_tTimeOut:= i_tTimeOut, 
-	iq_stSerialRXBuffer:= iq_stSerialRXBuffer,
-	iq_stSerialTXBuffer:= iq_stSerialTXBuffer );
+    i_tTimeOut:= i_tTimeOut,
+    iq_stSerialRXBuffer:= iq_stSerialRXBuffer,
+    iq_stSerialTXBuffer:= iq_stSerialTXBuffer );
 fbPITransaction.i_xExecute := FALSE;
 fbPITransaction(
-	i_tTimeOut:= i_tTimeOut, 
-	iq_stSerialRXBuffer:= iq_stSerialRXBuffer,
-	iq_stSerialTXBuffer:= iq_stSerialTXBuffer );
+    i_tTimeOut:= i_tTimeOut,
+    iq_stSerialRXBuffer:= iq_stSerialRXBuffer,
+    iq_stSerialTXBuffer:= iq_stSerialTXBuffer );
 fbPITransaction.i_xExpectReply:=TRUE;]]></ST>
       </Implementation>
     </Action>
     <Action Name="a_ErrorMesg" Id="{b3a6f4e0-9fb2-41d0-94af-43ceed0c99de}">
       <Implementation>
-        <ST><![CDATA[fbFormatString( sformat:=sErrMesg, 
-	arg1:=F_INT(iStep), 
-	arg2:=F_STRING(fbPITransaction.q_sResult),
-	sOut => q_sResult);
-	]]></ST>
+        <ST><![CDATA[fbFormatString( sformat:=sErrMesg,
+    arg1:=F_INT(iStep),
+    arg2:=F_STRING(fbPITransaction.q_sResult),
+    sOut => q_sResult);
+    ]]></ST>
       </Implementation>
     </Action>
     <Action Name="a_UnknownError" Id="{2912ef3a-1234-4e86-ad85-52ea704cf66e}">
       <Implementation>
         <ST><![CDATA[q_sResult:= 'Unknown error';
 
-fbFormatString( sformat:=sErrMesg, 
-	arg1:=F_INT(iStep), 
-	arg2:=F_STRING(q_sResult), //Little silly, but have to do this because F_STRING requires read/write access
-	sOut => q_sResult);]]></ST>
+fbFormatString( sformat:=sErrMesg,
+    arg1:=F_INT(iStep),
+    arg2:=F_STRING(q_sResult), //Little silly, but have to do this because F_STRING requires read/write access
+    sOut => q_sResult);]]></ST>
       </Implementation>
     </Action>
   </POU>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_PI_E621_SerialTransaction.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_PI_E621_SerialTransaction.TcPOU
@@ -1,52 +1,52 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.6">
   <POU Name="FB_PI_E621_SerialTransaction" Id="{262af350-d94c-4def-8e0a-b40258768256}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_PI_E621_SerialTransaction
 VAR_INPUT
-	/// rising edge execute 
-	i_xExecute: BOOL;
-	/// Maximum wait time for reply 
-	i_tTimeOut: TIME := TIME#1s0ms;
-	// Command field
-	i_sCmd: STRING;
-	// Axis field
-	i_sAxis: STRING;
-	// Parameter field
-	i_sParam: STRING;
-	// Does command have a reply?  Default behavior is the same as the other drivers.
-	i_xExpectReply: BOOL := TRUE;
+    /// rising edge execute
+    i_xExecute: BOOL;
+    /// Maximum wait time for reply
+    i_tTimeOut: TIME := TIME#1s0ms;
+    // Command field
+    i_sCmd: T_MaxString;
+    // Axis field
+    i_sAxis: T_MaxString;
+    // Parameter field
+    i_sParam: T_MaxString;
+    // Does command have a reply?  Default behavior is the same as the other drivers.
+    i_xExpectReply: BOOL := TRUE;
 END_VAR
 VAR_OUTPUT
-	q_xDone: BOOL;
-	q_sResponseData: STRING;
-	q_xError: BOOL;
-	q_xTimeout: BOOL;
-	q_sResult: STRING;
-	/// Last String Sent to Serial Device - for debugging 
-	q_sLastSentString: STRING;
-	/// Last String Received from Serial Device - for debugging 
-	q_sLastReceivedString: STRING;
+    q_xDone: BOOL;
+    q_sResponseData: STRING;
+    q_xError: BOOL;
+    q_xTimeout: BOOL;
+    q_sResult: T_MaxString;
+    /// Last String Sent to Serial Device - for debugging
+    q_sLastSentString: STRING;
+    /// Last String Received from Serial Device - for debugging
+    q_sLastReceivedString: STRING;
 END_VAR
 VAR_IN_OUT
-	iq_stSerialRXBuffer: ComBuffer;
-	iq_stSerialTXBuffer: ComBuffer;
+    iq_stSerialRXBuffer: ComBuffer;
+    iq_stSerialTXBuffer: ComBuffer;
 END_VAR
 VAR
-	rtExecute: R_TRIG;
-	iStep: INT;
-	fbClearComBuffer: ClearComBuffer;
-	sSendString: STRING;
-	fbFormatString: FB_FormatString;
-	iChecksum: INT;
-	fbSendString: SendString;
-	fbReceiveString: ReceiveString;
-	sReceivedString: STRING;
-	tonTimeout: TON;
-	sRXStringForChecksum: STRING;
-	sReceiveStringWOChecksum: STRING;
-	sRXCheckSum: STRING;
-	sRXAddress: STRING;
-	sRXParmNum: STRING;
+    rtExecute: R_TRIG;
+    iStep: INT;
+    fbClearComBuffer: ClearComBuffer;
+    sSendString: STRING;
+    fbFormatString: FB_FormatString;
+    iChecksum: INT;
+    fbSendString: SendString;
+    fbReceiveString: ReceiveString;
+    sReceivedString: STRING;
+    tonTimeout: TON;
+    sRXStringForChecksum: STRING;
+    sReceiveStringWOChecksum: STRING;
+    sRXCheckSum: STRING;
+    sRXAddress: STRING;
+    sRXParmNum: STRING;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[(* This function block performs serial transactions with a PI E-816 or compatible comm module *)
@@ -54,106 +54,106 @@ END_VAR]]></Declaration>
 (* rising edge trigger *)
 rtExecute(CLK:= i_xExecute);
 IF rtExecute.Q THEN
-	q_xDone	:= FALSE;
-	q_sResponseData := '';
-	q_xError := FALSE;
-	q_sResult:= '';
-	q_sLastSentString := '';
-	q_sLastReceivedString:= '';
-	iStep := 10;
+    q_xDone	:= FALSE;
+    q_sResponseData := '';
+    q_xError := FALSE;
+    q_sResult:= '';
+    q_sLastSentString := '';
+    q_sLastReceivedString:= '';
+    iStep := 10;
 END_IF
 
 CASE iStep OF
-	0:
-		; (* idle *)
+    0:
+        ; (* idle *)
 
-	10: (* clear com buffers *)
-		fbClearComBuffer(Buffer:= iq_stSerialRXBuffer);
-		fbClearComBuffer(Buffer:= iq_stSerialTXBuffer);
-		(* build the send string *)
-		IF i_sParam = '' AND i_sAxis <> '' THEN //Axis but no parameter
-			fbFormatString( sFormat:= '%s %s$L', 
-				arg1:= F_STRING(i_sCmd),
-				arg2:= F_STRING(i_sAxis),
-				sOut=> sSendString);
-		ELSIF i_sParam <> '' AND i_sAxis = '' THEN //Parameter but no axis, global command
-			fbFormatString( sFormat:= '%s %s$L', 
-				arg1:= F_STRING(i_sCmd),
-				arg2:= F_STRING(i_sParam), //May not work for all commands, good enough for now
-				sOut=> sSendString);
-		ELSIF i_sParam = '' AND i_sAxis = '' THEN //Global Query/Command
-			fbFormatString( sFormat:= '%s$L', 
-			arg1:= F_STRING(i_sCmd),
-			sOut=> sSendString);
-		ELSE
-			fbFormatString( sFormat:= '%s %s %s$L', 
-				arg1:= F_STRING(i_sCmd),
-				arg2:= F_STRING(i_sAxis),
-				arg3:= F_STRING(i_sParam), //May not work for all commands, good enough for now
-				sOut=> sSendString);
-		END_IF
-		(* send it *)
-		fbSendString( SendString:= sSendString, TXbuffer:= iq_stSerialTXBuffer );
-		q_sLastSentString := sSendString;
-		iStep := iStep + 10;
+    10: (* clear com buffers *)
+        fbClearComBuffer(Buffer:= iq_stSerialRXBuffer);
+        fbClearComBuffer(Buffer:= iq_stSerialTXBuffer);
+        (* build the send string *)
+        IF i_sParam = '' AND i_sAxis <> '' THEN //Axis but no parameter
+            fbFormatString( sFormat:= '%s %s$L',
+                arg1:= F_STRING(i_sCmd),
+                arg2:= F_STRING(i_sAxis),
+                sOut=> sSendString);
+        ELSIF i_sParam <> '' AND i_sAxis = '' THEN //Parameter but no axis, global command
+            fbFormatString( sFormat:= '%s %s$L',
+                arg1:= F_STRING(i_sCmd),
+                arg2:= F_STRING(i_sParam), //May not work for all commands, good enough for now
+                sOut=> sSendString);
+        ELSIF i_sParam = '' AND i_sAxis = '' THEN //Global Query/Command
+            fbFormatString( sFormat:= '%s$L',
+            arg1:= F_STRING(i_sCmd),
+            sOut=> sSendString);
+        ELSE
+            fbFormatString( sFormat:= '%s %s %s$L',
+                arg1:= F_STRING(i_sCmd),
+                arg2:= F_STRING(i_sAxis),
+                arg3:= F_STRING(i_sParam), //May not work for all commands, good enough for now
+                sOut=> sSendString);
+        END_IF
+        (* send it *)
+        fbSendString( SendString:= sSendString, TXbuffer:= iq_stSerialTXBuffer );
+        q_sLastSentString := sSendString;
+        iStep := iStep + 10;
 
-	20: (* Finish sending the String *)
-		IF fbSendString.Busy THEN
-			fbSendString( SendString:= sSendString, TXbuffer:= iq_stSerialTXBuffer );
-		ELSIF fbSendString.Error <> 0 THEN
-			q_sResult := CONCAT('In step 20 fbSendString resulted in error: ', INT_TO_STRING(fbSendString.Error));
-			iStep := 9000;
-		ELSIF NOT fbSendString.Busy THEN
-			IF i_xExpectReply THEN
-			iStep := iStep + 10;
-			ELSE //No reply expected, transaction complete
-			q_xDone:= TRUE;
-			q_sResult := 'Success.';
-			q_xTimeout := FALSE; //no timeout
-			iStep := 100;
-			END_IF
-		END_IF
-		(* Reset receive *)
-		fbReceiveString(
-			Reset:= TRUE,
-			ReceivedString:= sReceivedString,
-			RXbuffer:= iq_stSerialRXBuffer );
-		tonTimeout(IN:= FALSE);
+    20: (* Finish sending the String *)
+        IF fbSendString.Busy THEN
+            fbSendString( SendString:= sSendString, TXbuffer:= iq_stSerialTXBuffer );
+        ELSIF fbSendString.Error <> 0 THEN
+            q_sResult := CONCAT('In step 20 fbSendString resulted in error: ', INT_TO_STRING(fbSendString.Error));
+            iStep := 9000;
+        ELSIF NOT fbSendString.Busy THEN
+            IF i_xExpectReply THEN
+            iStep := iStep + 10;
+            ELSE //No reply expected, transaction complete
+            q_xDone:= TRUE;
+            q_sResult := 'Success.';
+            q_xTimeout := FALSE; //no timeout
+            iStep := 100;
+            END_IF
+        END_IF
+        (* Reset receive *)
+        fbReceiveString(
+            Reset:= TRUE,
+            ReceivedString:= sReceivedString,
+            RXbuffer:= iq_stSerialRXBuffer );
+        tonTimeout(IN:= FALSE);
 
-	30: (* Get reply, if there is one *)
-		fbReceiveString(
-			Prefix:= ,
-			Suffix:= '$L',
-			Timeout:= i_tTimeOut,
-			Reset:= FALSE,
-			ReceivedString:= sReceivedString,
-			RXbuffer:= iq_stSerialRXBuffer );
-		tonTimeout(IN:= TRUE, PT:= i_tTimeOut);
-		IF fbReceiveString.Error <> 0 AND fbReceiveString.Error <> 16#1008 THEN //16#1008 is timeout error
-			q_sResult := CONCAT('In step 30 fbReceiveString resulted in error: ', INT_TO_STRING(fbReceiveString.Error));
-			iStep := 9000;
-		ELSIF fbReceiveString.RxTimeout OR tonTimeout.Q THEN
-			q_sResult := 'Device failed to reply within timeout period';
-			q_xTimeout := TRUE;
-			iStep := 9000;
-		ELSIF fbReceiveString.StringReceived THEN
-			q_xTimeout := FALSE; //no timeout
-			q_sLastReceivedString := sReceivedString;
-			q_sResponseData := sReceivedString;
-			q_sResult := 'Success.';
-			q_xDone:= TRUE;
-			iStep := 100;
-		END_IF
+    30: (* Get reply, if there is one *)
+        fbReceiveString(
+            Prefix:= ,
+            Suffix:= '$L',
+            Timeout:= i_tTimeOut,
+            Reset:= FALSE,
+            ReceivedString:= sReceivedString,
+            RXbuffer:= iq_stSerialRXBuffer );
+        tonTimeout(IN:= TRUE, PT:= i_tTimeOut);
+        IF fbReceiveString.Error <> 0 AND fbReceiveString.Error <> 16#1008 THEN //16#1008 is timeout error
+            q_sResult := CONCAT('In step 30 fbReceiveString resulted in error: ', INT_TO_STRING(fbReceiveString.Error));
+            iStep := 9000;
+        ELSIF fbReceiveString.RxTimeout OR tonTimeout.Q THEN
+            q_sResult := 'Device failed to reply within timeout period';
+            q_xTimeout := TRUE;
+            iStep := 9000;
+        ELSIF fbReceiveString.StringReceived THEN
+            q_xTimeout := FALSE; //no timeout
+            q_sLastReceivedString := sReceivedString;
+            q_sResponseData := sReceivedString;
+            q_sResult := 'Success.';
+            q_xDone:= TRUE;
+            iStep := 100;
+        END_IF
 
-	100: (* done *)
-		IF  i_xExecute = FALSE THEN
-			q_xDone:= FALSE;
-			iStep := 0;
-		END_IF
+    100: (* done *)
+        IF  i_xExecute = FALSE THEN
+            q_xDone:= FALSE;
+            iStep := 0;
+        END_IF
 
-	9000:
-		q_xError := TRUE;
-		
+    9000:
+        q_xError := TRUE;
+
 END_CASE]]></ST>
     </Implementation>
   </POU>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/Version/Global_Version.TcGVL
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
     {attribute 'const_non_replaced'}
-    stLibVersion_lcls_twincat_optics : ST_LibVersion := (iMajor := 0, iMinor := 6, iBuild := 1, iRevision := 0, nFlags := 0, sVersion := '0.6.1');
+    stLibVersion_lcls_twincat_optics : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/Version/Global_Version.TcGVL
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/Version/Global_Version.TcGVL
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.6">
   <GVL Name="Global_Version" Id="{f98aab9b-240c-4c69-8c0a-e5732bdbece6}">
     <Declaration><![CDATA[{attribute 'TcGenerated'}
 {attribute 'no-analysis'}
 {attribute 'linkalways'}
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
-	{attribute 'const_non_replaced'}
-	stLibVersion_lcls_twincat_optics : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, sVersion := '0.0.0');
+    {attribute 'const_non_replaced'}
+    stLibVersion_lcls_twincat_optics : ST_LibVersion := (iMajor := 0, iMinor := 6, iBuild := 1, iRevision := 0, nFlags := 0, sVersion := '0.6.1');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
@@ -17,7 +17,7 @@
     <Company>SLAC</Company>
     <Released>false</Released>
     <Title>lcls-twincat-optics</Title>
-    <ProjectVersion>0.0.0</ProjectVersion>
+    <ProjectVersion>0.6.0</ProjectVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DUTs\DUT_HOMS.TcDUT">

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
@@ -17,7 +17,7 @@
     <Company>SLAC</Company>
     <Released>false</Released>
     <Title>lcls-twincat-optics</Title>
-    <ProjectVersion>0.6.0</ProjectVersion>
+    <ProjectVersion>0.6.1</ProjectVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DUTs\DUT_HOMS.TcDUT">

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
@@ -17,7 +17,7 @@
     <Company>SLAC</Company>
     <Released>false</Released>
     <Title>lcls-twincat-optics</Title>
-    <ProjectVersion>0.6.1</ProjectVersion>
+    <ProjectVersion>0.0.0</ProjectVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DUTs\DUT_HOMS.TcDUT">

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.tmc
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D33D3BD6-30E9-97FB-3A9D-EC2F76318875}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{9A25EA2E-5D95-A7FF-7649-D48D723D578B}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -45321,19 +45321,23 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.iMinor</Name>
-                <Value>0</Value>
+                <Value>6</Value>
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>0</Value>
+                <Value>1</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
                 <Value>0</Value>
               </SubItem>
               <SubItem>
+                <Name>.nFlags</Name>
+                <Value>0</Value>
+              </SubItem>
+              <SubItem>
                 <Name>.sVersion</Name>
-                <String>0.0.0</String>
+                <String>0.6.1</String>
               </SubItem>
             </Default>
             <Properties>
@@ -45756,7 +45760,7 @@ External Setpoint Generation:
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-06-21T10:48:49</Value>
+          <Value>2023-06-21T11:16:31</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.tmc
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.tmc
@@ -1,28 +1,10 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{FD684324-A181-4BA5-9140-1FCE14988BF3}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{D33D3BD6-30E9-97FB-3A9D-EC2F76318875}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
-    <DataType>
-      <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
-      <BitSize>48</BitSize>
-      <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
-      <ArrayInfo>
-        <LBound>0</LBound>
-        <Elements>6</Elements>
-      </ArrayInfo>
-      <Format>
-        <Printf>%d.%d.%d.%d.%d.%d</Printf>
-        <Parameter>[0]</Parameter>
-        <Parameter>[1]</Parameter>
-        <Parameter>[2]</Parameter>
-        <Parameter>[3]</Parameter>
-        <Parameter>[4]</Parameter>
-        <Parameter>[5]</Parameter>
-      </Format>
-    </DataType>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
       <Comment>Defacto system structure, must be included in all projects</Comment>
-      <BitSize>88</BitSize>
+      <BitSize>40</BitSize>
       <SubItem>
         <Name>xSwAlmRst</Name>
         <Type>BOOL</Type>
@@ -58,23 +40,12 @@
         <BitSize>8</BitSize>
         <BitOffs>32</BitOffs>
       </SubItem>
-      <SubItem>
-        <Name>I_EcatMaster1</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</Type>
-        <Comment> AMS Net ID used for FB_EcatDiag, among others </Comment>
-        <BitSize>48</BitSize>
-        <BitOffs>40</BitOffs>
-        <Properties>
-          <Property>
-            <Name>naming</Name>
-            <Value>omit</Value>
-          </Property>
-          <Property>
-            <Name>TcAddressType</Name>
-            <Value>Input</Value>
-          </Property>
-        </Properties>
-      </SubItem>
+      <Properties>
+        <Property>
+          <Name>analysis</Name>
+          <Value>-33</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_System">T_MaxString</Name>
@@ -83,7 +54,7 @@
       <BaseType>STRING(255)</BaseType>
     </DataType>
     <DataType>
-      <Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
+      <Name GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" TcBaseType="true" CName="TcEventSeverity*" RemovableEnumPrefix="TCEVENTSEVERITY_">TcEventSeverity</Name>
       <BitSize>16</BitSize>
       <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
       <EnumInfo>
@@ -123,6 +94,7 @@
       <Name Namespace="LCLS_General">E_Subsystem</Name>
       <BitSize>16</BitSize>
       <BaseType>WORD</BaseType>
+      <Comment>LCLS Defined subsystems, make sure these correspond with casSubsystems in FB_LogMessage</Comment>
       <EnumInfo>
         <Text>NILVALUE</Text>
         <Enum>0</Enum>
@@ -209,31 +181,31 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>79716432</GetCodeOffs>
+        <GetCodeOffs>79590184</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>79716504</GetCodeOffs>
+        <GetCodeOffs>79590256</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79716520</GetCodeOffs>
+        <GetCodeOffs>79590272</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79716480</GetCodeOffs>
+        <GetCodeOffs>79590232</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>79716512</GetCodeOffs>
+        <GetCodeOffs>79590264</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -273,6 +245,21 @@
         </Properties>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetString</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -286,6 +273,16 @@
           <Comment> buffer size in bytes</Comment>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -404,7 +401,7 @@
       </Properties>
     </DataType>
     <DataType>
-      <Name GUID="{05B507B4-8043-4A57-BCD7-5BC554B64B83}" TcBaseType="true" CName="TcSourceInfoType">TcSourceInfoType</Name>
+      <Name GUID="{05B507B4-8043-4A57-BCD7-5BC554B64B83}" TcBaseType="true" CName="TcSourceInfoType*">TcSourceInfoType</Name>
       <BitSize>32</BitSize>
       <BaseType GUID="{18071995-0000-0000-0000-000000000008}">UDINT</BaseType>
       <EnumInfo>
@@ -436,7 +433,7 @@
       </Hides>
     </DataType>
     <DataType>
-      <Name GUID="{02B179F9-9BBE-4D12-A24F-5E65C9CF659C}" TcBaseType="true" CName="TcSerializedSourceInfoType">TcSerializedSourceInfoType</Name>
+      <Name GUID="{02B179F9-9BBE-4D12-A24F-5E65C9CF659C}" TcBaseType="true" CName="TcSerializedSourceInfoType*">TcSerializedSourceInfoType</Name>
       <BitSize>96</BitSize>
       <SubItem>
         <Name>eType</Name>
@@ -597,8 +594,8 @@
       <BitSize>64</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
-        <Name RpcEnable="plc">__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <Name>__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
         <ReturnBitSize>128</ReturnBitSize>
         <Properties>
           <Property>
@@ -607,8 +604,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getipData</Name>
-        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}" RpcDirection="out">ITcSourceInfo</ReturnType>
+        <Name>__getipData</Name>
+        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Properties>
           <Property>
@@ -620,8 +617,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getnId</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__getnId</Name>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
@@ -634,8 +631,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getsName</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <Name>__getsName</Name>
+        <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Properties>
           <Property>
@@ -653,6 +650,7 @@
       </Method>
       <Method>
         <Name>EqualsTo</Name>
+        <Comment> returns TRUE if equal</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -663,7 +661,7 @@
       </Method>
     </DataType>
     <DataType>
-      <Name GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" TcBaseType="true" CName="TcEventEntry">TcEventEntry</Name>
+      <Name GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" TcBaseType="true" CName="TcEventEntry*">TcEventEntry</Name>
       <BitSize>192</BitSize>
       <SubItem>
         <Name>uuidEventClass</Name>
@@ -689,8 +687,8 @@
       <BitSize>64</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
-        <Name RpcEnable="plc">__geteSeverity</Name>
-        <ReturnType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" RpcDirection="out">TcEventSeverity</ReturnType>
+        <Name>__geteSeverity</Name>
+        <ReturnType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
         <Properties>
           <Property>
@@ -703,8 +701,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getEventClass</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <Name>__getEventClass</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
         <ReturnBitSize>128</ReturnBitSize>
         <Properties>
           <Property>
@@ -713,8 +711,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getipSourceInfo</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger" RpcDirection="out">I_TcSourceInfo</ReturnType>
+        <Name>__getipSourceInfo</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Properties>
           <Property>
@@ -727,8 +725,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getnEventId</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__getnEventId</Name>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
@@ -741,8 +739,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getsEventClassName</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <Name>__getsEventClassName</Name>
+        <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Properties>
           <Property>
@@ -759,8 +757,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getsEventText</Name>
-        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
+        <Name>__getsEventText</Name>
+        <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Properties>
           <Property>
@@ -777,8 +775,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getstEventEntry</Name>
-        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" RpcDirection="out">TcEventEntry</ReturnType>
+        <Name>__getstEventEntry</Name>
+        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</ReturnType>
         <ReturnBitSize>192</ReturnBitSize>
         <Properties>
           <Property>
@@ -788,6 +786,7 @@
       </Method>
       <Method>
         <Name>EqualsTo</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -798,6 +797,7 @@
       </Method>
       <Method>
         <Name>EqualsToEventClass</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -808,6 +808,7 @@
       </Method>
       <Method>
         <Name>EqualsToEventEntry</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -828,6 +829,7 @@
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -853,6 +855,9 @@
       </Method>
       <Method>
         <Name>RequestEventClassName</Name>
+        <Comment> Async request for event text.
+ Returns TRUE if async request is not any more busy.
+ Result is only output if no error occurred.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -898,6 +903,9 @@
       </Method>
       <Method>
         <Name>RequestEventText</Name>
+        <Comment> Async request for event text.
+ Returns TRUE if async request is not any more busy.
+ Result is only output if no error occurred.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -947,33 +955,33 @@
       <BitSize>64</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__GetInterfacePointer</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>pRef</Name>
-          <Type PointerTo="2" RpcDirection="in">DWORD</Type>
+          <Type PointerTo="2">DWORD</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__GetInterfaceReference</Name>
-        <ReturnType RpcDirection="out">BOOL</ReturnType>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
           <Name>nInterfaceId</Name>
-          <Type RpcDirection="in">DINT</Type>
+          <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Parameter>
           <Name>pRef</Name>
-          <Type PointerTo="2" RpcDirection="in">DWORD</Type>
+          <Type PointerTo="2">DWORD</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
     </DataType>
     <DataType>
-      <Name GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}" TcBaseType="true" CName="TcEventArgumentType">TcEventArgumentType</Name>
+      <Name GUID="{CBABCE69-289D-4490-A8FE-F81B1741D1A1}" TcBaseType="true" CName="TcEventArgumentType*">TcEventArgumentType</Name>
       <BitSize>16</BitSize>
       <BaseType GUID="{18071995-0000-0000-0000-000000000006}">INT</BaseType>
       <EnumInfo>
@@ -1056,6 +1064,14 @@
         <Text>Blob</Text>
         <Enum>19</Enum>
       </EnumInfo>
+      <EnumInfo>
+        <Text>AdsNotificationStream</Text>
+        <Enum>20</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>UTF8EncodedString</Text>
+        <Enum>21</Enum>
+      </EnumInfo>
       <Properties>
         <Property>
           <Name>plcAttribute_qualified_only</Name>
@@ -1066,6 +1082,7 @@
       </Properties>
       <Hides>
         <Hide GUID="{A1C88D80-AC7F-419E-838D-233C8A8C0184}"/>
+        <Hide GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}"/>
       </Hides>
     </DataType>
     <DataType>
@@ -1088,7 +1105,7 @@
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>eType</Name>
-          <Type GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}">TcEventArgumentType</Type>
+          <Type GUID="{CBABCE69-289D-4490-A8FE-F81B1741D1A1}">TcEventArgumentType</Type>
           <BitSize>16</BitSize>
         </Parameter>
         <Parameter>
@@ -1113,7 +1130,7 @@
         </Parameter>
         <Parameter>
           <Name>eType</Name>
-          <Type GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}" ReferenceTo="true">TcEventArgumentType</Type>
+          <Type GUID="{CBABCE69-289D-4490-A8FE-F81B1741D1A1}" ReferenceTo="true">TcEventArgumentType</Type>
           <BitSize X64="64">32</BitSize>
         </Parameter>
         <Parameter>
@@ -1133,7 +1150,7 @@
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
           <Name>pArgumentTypes</Name>
-          <Type GUID="{939C2FD3-7468-4E5B-AA5D-A64A143B36A8}" PointerTo="1">TcEventArgumentType</Type>
+          <Type GUID="{CBABCE69-289D-4490-A8FE-F81B1741D1A1}" PointerTo="1">TcEventArgumentType</Type>
           <BitSize X64="64">32</BitSize>
         </Parameter>
       </Method>
@@ -1163,8 +1180,8 @@
       <BitSize>64</BitSize>
       <ExtendsType>IQueryInterface</ExtendsType>
       <Method>
-        <Name RpcEnable="plc">__getipData</Name>
-        <ReturnType GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}" RpcDirection="out">ITcArguments</ReturnType>
+        <Name>__getipData</Name>
+        <ReturnType GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Properties>
           <Property>
@@ -1176,8 +1193,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc">__getnCount</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__getnCount</Name>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
@@ -1472,18 +1489,21 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79716312</GetCodeOffs>
-        <SetCodeOffs>79716360</SetCodeOffs>
+        <GetCodeOffs>79590056</GetCodeOffs>
+        <SetCodeOffs>79590104</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>79716392</GetCodeOffs>
-        <SetCodeOffs>79716416</SetCodeOffs>
+        <GetCodeOffs>79590136</GetCodeOffs>
+        <SetCodeOffs>79590160</SetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>ExtendName</Name>
+        <Comment> extends the source name on the right side of the string by the given extension.
+ If the source name string size is exceeded nothing more is extended.
+ Function returns TRUE is the concatenation succeeded.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -1493,8 +1513,8 @@
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__getipData</Name>
-        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}" RpcDirection="out">ITcSourceInfo</ReturnType>
+        <Name>__getipData</Name>
+        <ReturnType GUID="{F7BF6767-548B-493C-899B-06A477976F11}">ITcSourceInfo</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Local>
           <Name>ipData</Name>
@@ -1530,7 +1550,33 @@
         </Properties>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>ResetToDefault</Name>
+        <Comment> resets the source info to default values (name equals ads symbol name, id equals PLC object id)</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
@@ -1561,10 +1607,10 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="9">__setguid</Name>
+        <Name>__setguid</Name>
         <Parameter>
           <Name>guid</Name>
-          <Type GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="in">GUID</Type>
+          <Type GUID="{18071995-0000-0000-0000-000000000021}">GUID</Type>
           <BitSize>128</BitSize>
         </Parameter>
         <Properties>
@@ -1575,6 +1621,7 @@
       </Method>
       <Method>
         <Name>EqualsTo</Name>
+        <Comment> returns TRUE if equal</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -1584,8 +1631,8 @@
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="1">__getguid</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <Name>__getguid</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
         <ReturnBitSize>128</ReturnBitSize>
         <Local>
           <Name>guid</Name>
@@ -1679,7 +1726,7 @@
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>__REQUESTEVENTCLASSNAME__FBRESULT</Name>
+        <Name>__FB_TCEVENTBASE__REQUESTEVENTCLASSNAME__FBRESULT</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
         <BitSize>128</BitSize>
         <BitOffs>3712</BitOffs>
@@ -1690,7 +1737,7 @@
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>__REQUESTEVENTCLASSNAME__BBUSY</Name>
+        <Name>__FB_TCEVENTBASE__REQUESTEVENTCLASSNAME__BBUSY</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
         <BitOffs>3840</BitOffs>
@@ -1701,7 +1748,7 @@
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>__REQUESTEVENTTEXT__FBRESULT</Name>
+        <Name>__FB_TCEVENTBASE__REQUESTEVENTTEXT__FBRESULT</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">FB_AsyncStrResult</Type>
         <BitSize>128</BitSize>
         <BitOffs>3904</BitOffs>
@@ -1712,7 +1759,7 @@
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>__REQUESTEVENTTEXT__BBUSY</Name>
+        <Name>__FB_TCEVENTBASE__REQUESTEVENTTEXT__BBUSY</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
         <BitOffs>4032</BitOffs>
@@ -1726,40 +1773,41 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>79716616</GetCodeOffs>
+        <GetCodeOffs>79590368</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>79716576</GetCodeOffs>
+        <GetCodeOffs>79590328</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79716752</GetCodeOffs>
+        <GetCodeOffs>79590504</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79716760</GetCodeOffs>
+        <GetCodeOffs>79590512</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>79716672</GetCodeOffs>
+        <GetCodeOffs>79590424</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>79716768</GetCodeOffs>
+        <GetCodeOffs>79590520</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -1839,6 +1887,7 @@
       </Method>
       <Method>
         <Name>EqualsTo</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -1848,8 +1897,23 @@
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="7">__getipEvent</Name>
-        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}" RpcDirection="out">ITcEvent</ReturnType>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getipEvent</Name>
+        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Local>
           <Name>ipEvent</Name>
@@ -1866,8 +1930,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="3">__getEventClass</Name>
-        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}" RpcDirection="out">GUID</ReturnType>
+        <Name>__getEventClass</Name>
+        <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
         <ReturnBitSize>128</ReturnBitSize>
         <Local>
           <Name>EventClass</Name>
@@ -1910,8 +1974,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="13">__getstEventEntry</Name>
-        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}" RpcDirection="out">TcEventEntry</ReturnType>
+        <Name>__getstEventEntry</Name>
+        <ReturnType GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</ReturnType>
         <ReturnBitSize>192</ReturnBitSize>
         <Local>
           <Name>stEventEntry</Name>
@@ -1931,6 +1995,7 @@
       </Method>
       <Method>
         <Name>EqualsToEventEntry</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -1951,6 +2016,10 @@
       </Method>
       <Method>
         <Name>RequestEventText</Name>
+        <Comment> Async request for event text.
+ Returns TRUE if async request is not any more busy.
+ Result is only output if no error occurred.
+ Result string is UTF-8 encoded.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -2000,7 +2069,7 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__REQUESTEVENTTEXT__FBRESULT</Value>
+              <Value>__FB_TCEVENTBASE__REQUESTEVENTTEXT__FBRESULT</Value>
             </Property>
           </Properties>
         </Local>
@@ -2011,13 +2080,23 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__REQUESTEVENTTEXT__BBUSY</Value>
+              <Value>__FB_TCEVENTBASE__REQUESTEVENTTEXT__BBUSY</Value>
             </Property>
           </Properties>
         </Local>
       </Method>
       <Method>
         <Name>OnArgumentsChanged</Name>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name RpcEnable="plc" VTableIndex="11">__getsEventClassName</Name>
@@ -2043,8 +2122,8 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__getipArguments</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger" RpcDirection="out">I_TcArguments</ReturnType>
+        <Name>__getipArguments</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcArguments</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Local>
           <Name>ipArguments</Name>
@@ -2116,6 +2195,10 @@
       </Method>
       <Method>
         <Name>RequestEventClassName</Name>
+        <Comment> Async request for event text.
+ Returns TRUE if async request is not any more busy.
+ Result is only output if no error occurred.
+ Result string is UTF-8 encoded.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -2165,7 +2248,7 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__REQUESTEVENTCLASSNAME__FBRESULT</Value>
+              <Value>__FB_TCEVENTBASE__REQUESTEVENTCLASSNAME__FBRESULT</Value>
             </Property>
           </Properties>
         </Local>
@@ -2176,13 +2259,14 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__REQUESTEVENTCLASSNAME__BBUSY</Value>
+              <Value>__FB_TCEVENTBASE__REQUESTEVENTCLASSNAME__BBUSY</Value>
             </Property>
           </Properties>
         </Local>
       </Method>
       <Method>
         <Name>EqualsToEventEntryEx</Name>
+        <Comment> returns TRUE if equal.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -2355,7 +2439,7 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>79716816</GetCodeOffs>
+        <GetCodeOffs>79590576</GetCodeOffs>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -2375,6 +2459,7 @@
       </Method>
       <Method>
         <Name>CreateEx</Name>
+        <Comment> creates a TcCOM event object</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -2447,6 +2532,7 @@
       </Method>
       <Method>
         <Name>Create</Name>
+        <Comment> creates a TcCOM event object</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -2482,8 +2568,33 @@
         </Local>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="7">__getipEvent</Name>
-        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}" RpcDirection="out">ITcEvent</ReturnType>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getipEvent</Name>
+        <ReturnType GUID="{4A9CB0E9-8969-4B85-B567-605110511200}">ITcEvent</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Local>
           <Name>ipEvent</Name>
@@ -2501,6 +2612,7 @@
       </Method>
       <Method>
         <Name>Send</Name>
+        <Comment> send message to TC EventLogger</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -2512,6 +2624,7 @@
       </Method>
       <Method>
         <Name>Release</Name>
+        <Comment> releases the TcCOM object</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
@@ -2537,7 +2650,7 @@
       <Comment>
 	Falling Edge detection.
 </Comment>
-      <BitSize>96</BitSize>
+      <BitSize>128</BitSize>
       <SubItem>
         <Name>CLK</Name>
         <Type>BOOL</Type>
@@ -2578,6 +2691,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2593,7 +2731,7 @@
       <Comment>
 	Rising Edge detection.
 </Comment>
-      <BitSize>96</BitSize>
+      <BitSize>128</BitSize>
       <SubItem>
         <Name>CLK</Name>
         <Type>BOOL</Type>
@@ -2631,6 +2769,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2643,7 +2806,7 @@
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General">FB_LogMessage</Name>
-      <BitSize>86016</BitSize>
+      <BitSize>86080</BitSize>
       <SubItem>
         <Name>sMsg</Name>
         <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -2878,17 +3041,11 @@
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>nTotalEvents</Name>
-        <Type>UINT</Type>
+        <Name>nTimesViolated</Name>
+        <Type>INT</Type>
         <Comment>////////////////////////////</Comment>
         <BitSize>16</BitSize>
         <BitOffs>85344</BitOffs>
-      </SubItem>
-      <SubItem>
-        <Name>nTimesViolated</Name>
-        <Type>INT</Type>
-        <BitSize>16</BitSize>
-        <BitOffs>85360</BitOffs>
       </SubItem>
       <SubItem>
         <Name>LastCallTime</Name>
@@ -2917,27 +3074,27 @@
       <SubItem>
         <Name>ftTrippedReleased</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>85632</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bLocalTrickleTripped</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>85728</BitOffs>
+        <BitOffs>85760</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bLocalTripped</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>85736</BitOffs>
+        <BitOffs>85768</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bTripped</Name>
         <Type>BOOL</Type>
         <Comment> Won't emit messages if true</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>85744</BitOffs>
+        <BitOffs>85776</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -2953,7 +3110,7 @@
         <Name>bResetBreaker</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>85752</BitOffs>
+        <BitOffs>85784</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -2968,18 +3125,43 @@
       <SubItem>
         <Name>rtResetBreaker</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>85760</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>85824</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtTripped</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>85888</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>85952</BitOffs>
       </SubItem>
       <Action>
         <Name>CircuitBreaker</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -3048,9 +3230,25 @@
       </EnumInfo>
     </DataType>
     <DataType>
+      <Name>INT (2..100)</Name>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>2</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>100</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="Tc2_Utilities">E_HashPrefixTypes</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> Integer to string format prefixes </Comment>
       <EnumInfo>
         <Text>HASHPREFIX_IEC</Text>
         <Enum>0</Enum>
@@ -3066,6 +3264,7 @@
       <Name Namespace="Tc2_Utilities">E_SBCSType</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> Windows SBCS (Single Byte Character Set) Code Pages </Comment>
       <EnumInfo>
         <Text>eSBCS_WesternEuropean</Text>
         <Enum>1</Enum>
@@ -3087,6 +3286,7 @@
       <Name Namespace="Tc2_Utilities">E_RouteTransportType</Name>
       <BitSize>16</BitSize>
       <BaseType>UINT</BaseType>
+      <Comment> TwinCAT route transport types </Comment>
       <EnumInfo>
         <Text>eRouteTransport_None</Text>
         <Enum>0</Enum>
@@ -3191,6 +3391,7 @@
       <Name Namespace="Tc2_Utilities">E_ArgType</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> String format functions/fb's argument types </Comment>
       <EnumInfo>
         <Text>ARGTYPE_UNKNOWN</Text>
         <Enum>0</Enum>
@@ -3454,6 +3655,21 @@
       </SubItem>
     </DataType>
     <DataType>
+      <Name>UDINT (81..10000)</Name>
+      <BitSize>32</BitSize>
+      <BaseType>UDINT</BaseType>
+      <Properties>
+        <Property>
+          <Name>LowerBorder</Name>
+          <Value>81</Value>
+        </Property>
+        <Property>
+          <Name>UpperBorder</Name>
+          <Value>10000</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
       <Name Namespace="Tc2_Standard">TOF</Name>
       <BitSize>256</BitSize>
       <SubItem>
@@ -3520,6 +3736,31 @@
         <BitSize>32</BitSize>
         <BitOffs>224</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -3735,6 +3976,14 @@
         <Text>Type_Array_WORD</Text>
         <Enum>42</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="TcUnit">ST_TestCaseResult</Name>
@@ -3898,7 +4147,7 @@
     <DataType>
       <Name Namespace="TcUnit">FB_TestResults</Name>
       <Comment> This function block holds results of the complete test run, i.e. results for all test suites </Comment>
-      <BitSize>621296384</BitSize>
+      <BitSize>621296448</BitSize>
       <Implements Namespace="TcUnit">I_TestResults</Implements>
       <SubItem>
         <Name>TestSuiteResults</Name>
@@ -3917,29 +4166,30 @@
       <SubItem>
         <Name>StoringTestSuiteTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>621296256</BitOffs>
       </SubItem>
       <SubItem>
         <Name>StoredTestSuiteResults</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>621296352</BitOffs>
+        <BitOffs>621296384</BitOffs>
       </SubItem>
       <SubItem>
         <Name>StoredGeneralTestResults</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>621296360</BitOffs>
+        <BitOffs>621296392</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NumberOfTestsToAnalyse</Name>
         <Type>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestSuites)</Type>
         <BitSize>16</BitSize>
-        <BitOffs>621296368</BitOffs>
+        <BitOffs>621296400</BitOffs>
       </SubItem>
       <Method>
         <Name>GetAreTestResultsAvailable</Name>
+        <Comment> Returns whether the storing of the test results is finished </Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
       </Method>
@@ -3947,6 +4197,31 @@
         <Name>GetTestSuiteResults</Name>
         <ReturnType Namespace="TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Properties>
         <Property>
@@ -3985,7 +4260,7 @@
     provided by the Tc2_System library. This sends the result using ADS, which is consumed by the "Error List"
     of Visual Studio (which can print Errors, Warnings and Messages).
 </Comment>
-      <BitSize>384</BitSize>
+      <BitSize>448</BitSize>
       <Implements Namespace="TcUnit">I_TestResultLogger</Implements>
       <SubItem>
         <Name>TestResults</Name>
@@ -4002,7 +4277,7 @@
       <SubItem>
         <Name>PrintingTestSuiteTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>256</BitOffs>
       </SubItem>
       <SubItem>
@@ -4010,15 +4285,25 @@
         <Type>BOOL</Type>
         <Comment> This flag is set once the final end result has printed </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>352</BitOffs>
+        <BitOffs>384</BitOffs>
       </SubItem>
       <SubItem>
         <Name>PrintedTestSuitesResults</Name>
         <Type>BOOL</Type>
         <Comment> This flag is set once the test suites result have been printed </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>360</BitOffs>
+        <BitOffs>392</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Method>
         <Name>LogTestSuiteResults</Name>
         <Local>
@@ -4057,6 +4342,21 @@
           <BitSize>648</BitSize>
         </Local>
       </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -4073,6 +4373,19 @@
       <Name Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Name>
       <BitSize>32</BitSize>
       <BaseType>UDINT</BaseType>
+      <Comment> | Access mode
+ | File modes to open a file.
+
+ .. note::
+    For all ``*_PLUS`` modes be aware, that after reading from a file, writing can only be done after a call
+    to |SysFileGetPos| or |SysFileSetPos|! If you call |SysFileWrite| right after |SysFileRead|,
+    the file pointer could be on an invalid position!
+
+    Correct example::
+
+ 	     SysFileRead();
+ 	     SysFileGetPos();
+ 	     SysFileWrite();</Comment>
       <EnumInfo>
         <Text>AM_READ</Text>
         <Enum>0</Enum>
@@ -4103,6 +4416,12 @@
         <Enum>5</Enum>
         <Comment> Open an existing file with Append (read/write) access. If file does not exist, Open creates a new file</Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>external_name</Name>
+          <Value>RTS_ACCESS_MODE</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_SIZE</Name>
@@ -4137,7 +4456,20 @@
         <BitOffs>128</BitOffs>
       </SubItem>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Read</Name>
+        <Comment>
+    Reads a file from disk into the buffer
+</Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -4166,11 +4498,32 @@
       </Method>
       <Method>
         <Name>Close</Name>
+        <Comment>
+    Closes the currently opened file.
+</Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Open</Name>
+        <Comment>
+    Opens a file
+</Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -4187,6 +4540,9 @@
       </Method>
       <Method>
         <Name>Delete</Name>
+        <Comment>
+    Deletes a file specified by name, if it exists.
+</Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -4198,6 +4554,9 @@
       </Method>
       <Method>
         <Name>Write</Name>
+        <Comment>
+    Writes the contents of the buffer into a file.
+</Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -4240,6 +4599,14 @@
         <Text>Error</Text>
         <Enum>3</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="TcUnit">FB_StreamBuffer</Name>
@@ -4314,6 +4681,10 @@
       </Method>
       <Method>
         <Name>Find</Name>
+        <Comment>
+    Find a searchstring in the buffer and returns its position.
+    It's possible to add a preffered startposition within buffer
+</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -4378,8 +4749,26 @@
         </Local>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="3">__getLength</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__getLength</Name>
+        <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>Length</Name>
@@ -4393,7 +4782,20 @@
         </Properties>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Clear</Name>
+        <Comment>
+    Clears the buffer and sets the length to 0
+</Comment>
         <Local>
           <Name>Count</Name>
           <Type>UDINT</Type>
@@ -4401,13 +4803,16 @@
         </Local>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="5">__setAppend</Name>
+        <Name>__setAppend</Name>
+        <Comment>
+    Appends a string to the buffer
+</Comment>
         <Parameter>
           <Name>Append</Name>
           <Comment>
     Appends a string to the buffer
 </Comment>
-          <Type Namespace="Tc2_System" RpcDirection="in">T_MaxString</Type>
+          <Type Namespace="Tc2_System">T_MaxString</Type>
           <BitSize>2048</BitSize>
         </Parameter>
         <Local>
@@ -4427,8 +4832,11 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="0">__getBufferSize</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__getBufferSize</Name>
+        <Comment>
+    Read current Buffersize
+</Comment>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>BufferSize</Name>
@@ -4442,13 +4850,16 @@
         </Properties>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="6">__setLength</Name>
+        <Name>__setLength</Name>
+        <Comment>
+    Gets/Sets the current length (in bytes) of the streambuffer
+</Comment>
         <Parameter>
           <Name>Length</Name>
           <Comment>
     Gets/Sets the current length (in bytes) of the streambuffer
 </Comment>
-          <Type RpcDirection="in">UDINT</Type>
+          <Type>UDINT</Type>
           <BitSize>32</BitSize>
         </Parameter>
         <Properties>
@@ -4476,6 +4887,9 @@
       </Method>
       <Method>
         <Name>Copy</Name>
+        <Comment>
+    Copies a string from the character buffer
+</Comment>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
@@ -4716,6 +5130,11 @@
       </SubItem>
       <Method>
         <Name>NewParameter</Name>
+        <Comment>
+    Must be called after opening a new tag
+
+    XML.NewParameter(Name: = 'ParaName', Value: = 'Value');
+</Comment>
         <Parameter>
           <Name>Name</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -4728,7 +5147,28 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>NewTag</Name>
+        <Comment>
+    Creates a new Tag:
+    XML: &lt;MyTag&gt;
+
+    XML.NewTag(Name: = 'MyTag');
+</Comment>
         <Parameter>
           <Name>Name</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -4737,6 +5177,12 @@
       </Method>
       <Method>
         <Name>CloseTag</Name>
+        <Comment>
+    Closes a Tag:
+    XML: &lt;MyTag /&gt;'
+
+    Method: XML.CloseTag();
+</Comment>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Local>
@@ -4747,6 +5193,14 @@
       </Method>
       <Method>
         <Name>WriteDocumentHeader</Name>
+        <Comment>
+    Add your own preffered fileheader like:
+    XML: &lt;?xml version="1.0" encoding="UTF-8"?&gt;
+    
+    Start with calling this method before appending any other tags!
+
+    XML.WriteDocumentHeader('&lt;?xml version="1.0" encoding="UTF-8"?&gt;');
+</Comment>
         <Parameter>
           <Name>Header</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -4755,6 +5209,12 @@
       </Method>
       <Method>
         <Name>NewComment</Name>
+        <Comment>
+    Adds a comment
+    XML: &lt;!-- MyComment --&gt;
+
+    XML.NewComment(Comment: = 'MyComment');
+</Comment>
         <Parameter>
           <Name>Comment</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -4762,8 +5222,8 @@
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="2">__getLength</Name>
-        <ReturnType RpcDirection="out">UDINT</ReturnType>
+        <Name>__getLength</Name>
+        <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
           <Name>Length</Name>
@@ -4775,6 +5235,16 @@
             <Name>property</Name>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>NewTagData</Name>
@@ -4801,9 +5271,16 @@
       </Method>
       <Method>
         <Name>ClearBuffer</Name>
+        <Comment>
+    Clears the contents of the entire buffer.
+</Comment>
       </Method>
       <Method>
         <Name>ToStartBuffer</Name>
+        <Comment>
+    Jump to the beginning of the XML data
+    XML.ToStartBuffer();
+</Comment>
       </Method>
       <Properties>
         <Property>
@@ -4876,16 +5353,36 @@
       <SubItem>
         <Name>PublishTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>530816</BitOffs>
       </SubItem>
       <Method>
         <Name>DeleteOpenWriteClose</Name>
+        <Comment>
+    Deletes the former file (if it exists).
+    Opens the file, writes the buffer and closes it.
+</Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>LogTestSuiteResults</Name>
+        <Comment>
+    This method is responsible for the entire generation of the output file. 
+    The output of the xml writer is NOT beautified.
+    
+    When new data is available, feel free to add it to the report
+</Comment>
         <Local>
           <Name>UnitTestResults</Name>
           <Type Namespace="TcUnit" ReferenceTo="true">ST_TestSuiteResults</Type>
@@ -4918,6 +5415,21 @@
         </Local>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>Initialised</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -4934,7 +5446,7 @@
       <Comment>
     This function block is responsible for holding track of the tests and executing them.
 </Comment>
-      <BitSize>621828352</BitSize>
+      <BitSize>621828480</BitSize>
       <SubItem>
         <Name>AllTestSuitesFinished</Name>
         <Type>BOOL</Type>
@@ -4949,7 +5461,7 @@
         <Name>TestResults</Name>
         <Type Namespace="TcUnit">FB_TestResults</Type>
         <Comment> Test result information </Comment>
-        <BitSize>621296384</BitSize>
+        <BitSize>621296448</BitSize>
         <BitOffs>128</BitOffs>
       </SubItem>
       <SubItem>
@@ -4957,8 +5469,8 @@
         <Type Namespace="TcUnit">FB_AdsTestResultLogger</Type>
         <Comment> Prints the results to ADS so that Visual Studio can display the results.
        This test result formatter can be replaced with something else than ADS </Comment>
-        <BitSize>384</BitSize>
-        <BitOffs>621296512</BitOffs>
+        <BitSize>448</BitSize>
+        <BitOffs>621296576</BitOffs>
         <Properties>
           <Property>
             <Name>old_input_assignments</Name>
@@ -4969,7 +5481,7 @@
         <Name>TestResultLogger</Name>
         <Type Namespace="TcUnit">I_TestResultLogger</Type>
         <BitSize>64</BitSize>
-        <BitOffs>621296896</BitOffs>
+        <BitOffs>621297024</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AbortRunningTestSuites</Name>
@@ -4977,14 +5489,14 @@
         <Comment> If this flag is set, it means that some external event triggered the
        request to abort running the test suites </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>621296960</BitOffs>
+        <BitOffs>621297088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>xUnitXmlPublisher</Name>
         <Type Namespace="TcUnit">FB_xUnitXmlPublisher</Type>
         <Comment> Publishes a xUnit compatible XML file </Comment>
         <BitSize>530944</BitSize>
-        <BitOffs>621297024</BitOffs>
+        <BitOffs>621297152</BitOffs>
         <Properties>
           <Property>
             <Name>old_input_assignments</Name>
@@ -4995,30 +5507,58 @@
         <Name>XmlTestResultPublisher</Name>
         <Type Namespace="TcUnit">I_TestResultLogger</Type>
         <BitSize>64</BitSize>
-        <BitOffs>621827968</BitOffs>
+        <BitOffs>621828096</BitOffs>
       </SubItem>
       <SubItem>
-        <Name>__RUNTESTSUITETESTSINSEQUENCE__CURRENTLYRUNNINGTESTSUITE</Name>
+        <Name>__FB_TCUNITRUNNER__RUNTESTSUITETESTSINSEQUENCE__CURRENTLYRUNNINGTESTSUITE</Name>
         <Type>UINT</Type>
         <Comment> This variable holds which current test suite is being called, as we are running
        each one in a sequence (one by one) </Comment>
         <BitSize>16</BitSize>
-        <BitOffs>621828032</BitOffs>
+        <BitOffs>621828160</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
       </SubItem>
       <SubItem>
-        <Name>__RUNTESTSUITETESTSINSEQUENCE__TIMERBETWEENEXECUTIONOFTESTSUITES</Name>
+        <Name>__FB_TCUNITRUNNER__RUNTESTSUITETESTSINSEQUENCE__TIMERBETWEENEXECUTIONOFTESTSUITES</Name>
         <Type Namespace="Tc2_Standard">TOF</Type>
         <BitSize>256</BitSize>
-        <BitOffs>621828096</BitOffs>
+        <BitOffs>621828224</BitOffs>
       </SubItem>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AbortRunningTestSuiteTests</Name>
+        <Comment> This function sets a flag which makes the runner stop running the tests
+   in the test suites </Comment>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>RunTestSuiteTestsInSequence</Name>
+        <Comment> This runs all the test suites in sequence (one after the other) </Comment>
         <Parameter>
           <Name>TimeBetweenTestSuitesExecution</Name>
           <Comment> Time delay between a test suite is finished and the next test suite starts</Comment>
@@ -5048,7 +5588,7 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__RUNTESTSUITETESTSINSEQUENCE__CURRENTLYRUNNINGTESTSUITE</Value>
+              <Value>__FB_TCUNITRUNNER__RUNTESTSUITETESTSINSEQUENCE__CURRENTLYRUNNINGTESTSUITE</Value>
             </Property>
           </Properties>
         </Local>
@@ -5059,13 +5599,14 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__RUNTESTSUITETESTSINSEQUENCE__TIMERBETWEENEXECUTIONOFTESTSUITES</Value>
+              <Value>__FB_TCUNITRUNNER__RUNTESTSUITETESTSINSEQUENCE__TIMERBETWEENEXECUTIONOFTESTSUITES</Value>
             </Property>
           </Properties>
         </Local>
       </Method>
       <Method>
         <Name>RunTestSuiteTests</Name>
+        <Comment> This runs all the test suites in parallel </Comment>
         <Local>
           <Name>Counter</Name>
           <Type>UINT</Type>
@@ -5155,6 +5696,21 @@
         <BitOffs>4216</BitOffs>
       </SubItem>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetAssertionType</Name>
         <ReturnType Namespace="TcUnit">E_AssertionType</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -5184,7 +5740,18 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>SetTestOrder</Name>
+        <Comment> Sets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
         <Parameter>
           <Name>OrderNumber</Name>
           <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
@@ -5213,9 +5780,11 @@
       </Method>
       <Method>
         <Name>SetSkipped</Name>
+        <Comment> Sets the test case to skipped </Comment>
       </Method>
       <Method>
         <Name>SetAssertionMessage</Name>
+        <Comment> Sets the assertion message. If one already exists, it's not overwritten as we keep the first assertion in the test </Comment>
         <Parameter>
           <Name>AssertMessage</Name>
           <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -5224,6 +5793,7 @@
       </Method>
       <Method>
         <Name>SetAssertionType</Name>
+        <Comment> Sets the assertion type. If one already exists, it's not overwritten as we keep the first assertion in the test </Comment>
         <Parameter>
           <Name>AssertType</Name>
           <Type Namespace="TcUnit">E_AssertionType</Type>
@@ -5237,6 +5807,7 @@
       </Method>
       <Method>
         <Name>GetTestOrder</Name>
+        <Comment> Gets in which order/sequence relative to the order tests should this test be executed/evaluated. </Comment>
         <ReturnType>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
       </Method>
@@ -5427,6 +5998,17 @@
         <Text>TYPE_BITCONST</Text>
         <Enum>38</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>m4export_hide</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name>AnyType</Name>
@@ -5457,7 +6039,7 @@
     </DataType>
     <DataType>
       <Name Namespace="Tc2_System">FW_GetCurTaskIndex</Name>
-      <BitSize>96</BitSize>
+      <BitSize>128</BitSize>
       <SubItem>
         <Name>nIndex</Name>
         <Type>BYTE</Type>
@@ -5470,6 +6052,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -5500,7 +6107,7 @@
       <SubItem>
         <Name>fbGetCurTaskIndex</Name>
         <Type Namespace="Tc2_System">FW_GetCurTaskIndex</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>128</BitOffs>
         <Properties>
           <Property>
@@ -5508,6 +6115,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -5522,6 +6154,7 @@
       <Name Namespace="Tc2_Utilities">E_TypeFieldParam</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> String format argument types </Comment>
       <EnumInfo>
         <Text>TYPEFIELD_UNKNOWN</Text>
         <Enum>0</Enum>
@@ -5989,6 +6622,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -6161,8 +6819,13 @@
       </EnumInfo>
       <EnumInfo>
         <Text>TYPE_INTERFACE</Text>
-        <Enum>-4096</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>compatibility_id</Name>
+          <Value>52A6FD6D-031C-41c0-A818-0F45FE19AF8F</Value>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="TcUnit">U_ExpectedOrActual</Name>
@@ -6425,6 +7088,16 @@
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
@@ -6451,6 +7124,21 @@
           <Type>UINT</Type>
           <BitSize>16</BitSize>
         </Local>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
@@ -6602,6 +7290,33 @@
       </Method>
       <Method>
         <Name>ReportResult</Name>
+        <Comment>
+    This method is called in every assert and returns whether this particular assert has already been called.
+    The reason one would like to know whether this assert has already been reported or not is to not report it several
+    times to any logging service. Because a test-suite can consist of several tests, and certain tests can require the
+    test to run over several cycles it means that certain asserts could be called several times and thus we need to
+    keep track of which asserts we've already reported. The user of the framework should not need to care for any of
+    this and he/she should be able to call the asserts in any way they find suitable.
+
+    To know what assert this is we need to check for the total combination of:
+    - Test message
+    - Test instance path
+    - Expected value
+    - Actual value
+    Theoretically we can have a situation where a test has three different asserts, each and one with the same test
+    message/test instance path/actual value/expected value but called within the same or different cycles. In order for
+    us to handle all situations we need a simple algorithm that works according to:
+    - Keep track of how many instances the combination of test message/test instance path/expected value/actual value
+      we have. So for example, if we have called Assert(Exp := 5, Act := 5, 'Hello there', 'PRG.InstanceTestSuite.Test')
+      two times in one cycle, we have two instances of that combination. This is done according to:
+    - Iterate all existing reports.
+      - If we have a new PLC-cycle, set the current detection-count to zero.
+      - If new report does not match in any of the above fields, create it (together with current PLC-cycle).
+        Also store the information that we have one instance of this combination and +1 on the detection-count.
+      - If new report matches in all of the above, +1 in the detection-count. If this detection-count is larger than
+        the stored detection-count for this combination, create a new report and add +1 to the storage of
+        the detection-count.
+</Comment>
         <Parameter>
           <Name>ExpectedSize</Name>
           <Type>UDINT</Type>
@@ -6886,6 +7601,31 @@
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
@@ -7005,6 +7745,36 @@
       </Method>
       <Method>
         <Name>ReportResult</Name>
+        <Comment>
+    This method is called in every assert and returns whether this particular assert has already been called.
+    The reason one would like to know whether this assert has already been reported or not is to not report it several
+    times to any logging service. Because a test-suite can consist of several tests, and certain tests can require the
+    test to run over several cycles it means that certain asserts could be called several times and thus we need to
+    keep track of which asserts we've already reported. The user of the framework should not need to care for any of
+    this and he/she should be able to call the asserts in any way they find suitable.
+
+    To know what assert this is we need to check for the total combination of:
+    - Test message
+    - Test instance path
+    - Expecteds size (in bytes)
+    - Actuals size (in bytes)
+    - Expecteds datatype
+    - Actuals datatype
+    Theoretically we can have a situation where a test has three different asserts, each and one with the same test
+    message/test instance path/actuals size&amp;datatype/expecteds size&amp;datatype but called within the same or different
+    cycles. In order for us to handle all situations we need a simple algorithm that works according to:
+    - Keep track of how many instances the combination of test message/test instance path/expecteds size&amp;datatype/
+      actuals size&amp;datatype we have. So for example, if we have called
+      Assert(Exp := [5,4,3], Act := [5,4,3], 'Hello there', 'PRG.InstanceTestSuite.Test')
+      two times in one cycle, we have two instances of that combination. This is done according to:
+    - Iterate all existing reports.
+      - If we have a new PLC-cycle, set the current detection-count to zero.
+      - If new report does not match in any of the above fields, create it (together with current PLC-cycle).
+        Also store the information that we have one instance of this combination and +1 on the detection-count.
+      - If new report matches in all of the above, +1 in the detection-count. If this detection-count is larger than
+        the stored detection-count for this combination, create a new report and add +1 to the storage of
+        the detection-count.
+</Comment>
         <Parameter>
           <Name>ExpectedsSize</Name>
           <Type>UDINT</Type>
@@ -7194,7 +7964,7 @@
     This function block is responsible for making sure that the asserted test instance path and test message are not
     loo long. The total printed message can not be more than 253 characters long.
 </Comment>
-      <BitSize>11616</BitSize>
+      <BitSize>11648</BitSize>
       <SubItem>
         <Name>MsgFmtString</Name>
         <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -7279,6 +8049,31 @@
           <Value>253</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -7295,6 +8090,31 @@
 </Comment>
       <BitSize>128</BitSize>
       <Implements Namespace="TcUnit">I_AssertMessageFormatter</Implements>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Method>
         <Name>LogAssertFailure</Name>
         <Parameter>
@@ -7320,7 +8140,7 @@
         <Local>
           <Name>AdjustAssertFailureMessageToMax253CharLength</Name>
           <Type Namespace="TcUnit">FB_AdjustAssertFailureMessageToMax253CharLength</Type>
-          <BitSize>11616</BitSize>
+          <BitSize>11648</BitSize>
         </Local>
         <Local>
           <Name>TestInstancePathCleaned</Name>
@@ -7362,7 +8182,7 @@
    It's also responsible for providing all the assert-methods for asserting different data types.
    Only failed assertions are recorded.
 </Comment>
-      <BitSize>33558784</BitSize>
+      <BitSize>33561984</BitSize>
       <SubItem>
         <Name>InstancePath</Name>
         <Type Namespace="Tc2_System">T_MaxString</Type>
@@ -7415,7 +8235,7 @@
         </ArrayInfo>
         <Comment> Rising trigger of whether we have already notified the user of that the test name pointed to by the current
        position is a duplicate </Comment>
-        <BitSize>9600</BitSize>
+        <BitSize>12800</BitSize>
         <BitOffs>424832</BitOffs>
       </SubItem>
       <SubItem>
@@ -7428,19 +8248,19 @@
         <Comment> Last cycle count index for a specific test. Used to detect whether this test has already been defined in the
        current test suite </Comment>
         <BitSize>3200</BitSize>
-        <BitOffs>434432</BitOffs>
+        <BitOffs>437632</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AssertResults</Name>
         <Type Namespace="TcUnit">FB_AssertResultStatic</Type>
         <BitSize>24640448</BitSize>
-        <BitOffs>437632</BitOffs>
+        <BitOffs>440832</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AssertArrayResults</Name>
         <Type Namespace="TcUnit">FB_AssertArrayResultStatic</Type>
         <BitSize>8480448</BitSize>
-        <BitOffs>25078080</BitOffs>
+        <BitOffs>25081280</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AdsAssertMessageFormatter</Name>
@@ -7448,30 +8268,33 @@
         <Comment> Prints the failed asserts to ADS so that Visual Studio can display the assert message.
        This assert formatter can be replaced with something else than ADS </Comment>
         <BitSize>128</BitSize>
-        <BitOffs>33558528</BitOffs>
+        <BitOffs>33561728</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AssertMessageFormatter</Name>
         <Type Namespace="TcUnit">I_AssertMessageFormatter</Type>
         <BitSize>64</BitSize>
-        <BitOffs>33558656</BitOffs>
+        <BitOffs>33561856</BitOffs>
       </SubItem>
       <SubItem>
         <Name>HasStartedRunning</Name>
         <Type>BOOL</Type>
         <Comment> Indication whether this test suite has started running its tests </Comment>
         <BitSize>8</BitSize>
-        <BitOffs>33558720</BitOffs>
+        <BitOffs>33561920</BitOffs>
       </SubItem>
       <SubItem>
         <Name>NumberOfOrderedTests</Name>
         <Type>UINT (0..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</Type>
         <Comment> Number of ordered tests (created by TEST_ORDERED()) that this test suite contains </Comment>
         <BitSize>16</BitSize>
-        <BitOffs>33558736</BitOffs>
+        <BitOffs>33561936</BitOffs>
       </SubItem>
       <Method>
         <Name>AssertEquals_LINT</Name>
+        <Comment>
+    Asserts that two LINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> LINT expected value</Comment>
@@ -7508,6 +8331,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_ULINT</Name>
+        <Comment>
+    Asserts that two ULINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> ULINT array with expected values</Comment>
@@ -7599,19 +8425,18 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>FindTestSuiteInstancePath</Name>
+        <Comment> Searches for the instance path of the calling function block </Comment>
         <ReturnType Namespace="Tc2_System">T_MaxString</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
       </Method>
       <Method>
         <Name>AssertEquals_TIME</Name>
+        <Comment>
+    Asserts that two TIMEs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> TIME expected value</Comment>
@@ -7643,6 +8468,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_TIME_OF_DAY</Name>
+        <Comment>
+    Asserts that two TIME_OF_DAYs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> TIME_OF_DAY expected value</Comment>
@@ -7674,6 +8502,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_BYTE</Name>
+        <Comment>
+    Asserts that two BYTEs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> BYTE expected value</Comment>
@@ -7704,6 +8535,21 @@
         </Local>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetNumberOfFailedTests</Name>
         <ReturnType>UINT</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
@@ -7730,6 +8576,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_DATE_AND_TIME</Name>
+        <Comment>
+    Asserts that two DATE_AND_TIMEs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> DATE_AND_TIME expected value</Comment>
@@ -7761,6 +8610,7 @@
       </Method>
       <Method>
         <Name>GetTestByPosition</Name>
+        <Comment> This method returns the test at the n'th position, ranging from 1.. NumberOfTests </Comment>
         <ReturnType Namespace="TcUnit">FB_Test</ReturnType>
         <ReturnBitSize>4224</ReturnBitSize>
         <Parameter>
@@ -7771,6 +8621,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_BOOL</Name>
+        <Comment>
+    Asserts that two BOOL arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> BOOL array with expected values</Comment>
@@ -7862,14 +8715,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_BYTE</Name>
+        <Comment>
+    Asserts that two BYTE arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> BYTE array with expected values</Comment>
@@ -7971,14 +8822,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_DATE</Name>
+        <Comment>
+    Asserts that two DATEs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> DATE expected value</Comment>
@@ -8010,6 +8859,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_WORD</Name>
+        <Comment>
+    Asserts that two WORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> WORD expected value</Comment>
@@ -8041,6 +8893,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_LINT</Name>
+        <Comment>
+    Asserts that two LINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> LINT array with expected values</Comment>
@@ -8132,14 +8987,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_LTIME</Name>
+        <Comment>
+    Asserts that two LTIMEs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> LTIME expected value</Comment>
@@ -8171,6 +9024,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_UINT</Name>
+        <Comment>
+    Asserts that two UINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> UINT array with expected values</Comment>
@@ -8262,14 +9118,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREALs are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> LREAL expected value</Comment>
@@ -8307,6 +9161,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_LWORD</Name>
+        <Comment>
+    Asserts that two LWORD arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> LWORD array with expected values</Comment>
@@ -8408,14 +9265,14 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals</Name>
+        <Comment>
+    Asserts that two objects (of any type) are equal. If they are not, an assertion error is created.
+    For REAL and LREAL it's recommended to use the AssertEquals_REAL or AssertEquals_LREAL respectively
+    as these give the possibility to specify a delta between the expected and actual value.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> Expected value</Comment>
@@ -8722,6 +9579,9 @@
       </Method>
       <Method>
         <Name>AssertFalse</Name>
+        <Comment>
+    Asserts that a condition is false. If it is not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Condition</Name>
           <Comment> Condition to be checked</Comment>
@@ -8737,6 +9597,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_SINT</Name>
+        <Comment>
+    Asserts that two SINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> SINT expected value</Comment>
@@ -8768,6 +9631,9 @@
       </Method>
       <Method>
         <Name>AssertArray2dEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> LREAL 2d array with expected values</Comment>
@@ -8956,6 +9822,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_ULINT</Name>
+        <Comment>
+    Asserts that two ULINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> ULINT expected value</Comment>
@@ -8987,6 +9856,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_BOOL</Name>
+        <Comment>
+    Asserts that two BOOLs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> BOOL expected value</Comment>
@@ -9018,6 +9890,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> USINT expected value</Comment>
@@ -9049,6 +9924,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_LWORD</Name>
+        <Comment>
+    Asserts that two LWORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> LWORD expected value</Comment>
@@ -9080,6 +9958,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_USINT</Name>
+        <Comment>
+    Asserts that two USINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> USINT array with expected values</Comment>
@@ -9171,11 +10052,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>SetHasStartedRunning</Name>
@@ -9235,6 +10111,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORD arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> DWORD array with expected values</Comment>
@@ -9336,11 +10215,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>GetHasStartedRunning</Name>
@@ -9349,6 +10223,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> LREAL array with expected values</Comment>
@@ -9446,14 +10323,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_WSTRING</Name>
+        <Comment>
+    Asserts that two WSTRINGs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> WSTRING expected value</Comment>
@@ -9505,6 +10380,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> REAL array with expected values</Comment>
@@ -9602,14 +10480,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> DINT expected value</Comment>
@@ -9641,6 +10517,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_DINT</Name>
+        <Comment>
+    Asserts that two DINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> DINT array with expected values</Comment>
@@ -9732,14 +10611,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertEquals_STRING</Name>
+        <Comment>
+    Asserts that two STRINGs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> STRING expected value</Comment>
@@ -9771,6 +10648,9 @@
       </Method>
       <Method>
         <Name>SetTestFinished</Name>
+        <Comment> Marks the test as finished in this testsuite.
+   Returns TRUE if test was found, and FALSE if a test with this name was not found in this testsuite
+</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -9811,6 +10691,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_WORD</Name>
+        <Comment>
+    Asserts that two WORD arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> WORD array with expected values</Comment>
@@ -9912,14 +10795,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArray3dEquals_LREAL</Name>
+        <Comment>
+    Asserts that two LREAL 3D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> LREAL 3d array with expected values</Comment>
@@ -10108,6 +10989,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_INT</Name>
+        <Comment>
+    Asserts that two INT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> INT array with expected values</Comment>
@@ -10199,11 +11083,6 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>CalculateAndSetNumberOfAssertsForTest</Name>
@@ -10260,6 +11139,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_DWORD</Name>
+        <Comment>
+    Asserts that two DWORDs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> DWORD expected value</Comment>
@@ -10291,6 +11173,9 @@
       </Method>
       <Method>
         <Name>AssertTrue</Name>
+        <Comment>
+    Asserts that a condition is true. If it is not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Condition</Name>
           <Comment> Condition to be checked</Comment>
@@ -10306,6 +11191,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_INT</Name>
+        <Comment>
+    Asserts that two INTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> INT expected value</Comment>
@@ -10337,6 +11225,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_UINT</Name>
+        <Comment>
+    Asserts that two UINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> UINT expected value</Comment>
@@ -10367,7 +11258,20 @@
         </Local>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>AssertArray2dEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> REAL 2d array with expected values</Comment>
@@ -10619,6 +11523,9 @@
       </Method>
       <Method>
         <Name>AssertArray3dEquals_REAL</Name>
+        <Comment>
+    Asserts that two REAL 3D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> REAL 3d array with expected values</Comment>
@@ -10838,6 +11745,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_UDINT</Name>
+        <Comment>
+    Asserts that two UDINTs are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> UDINT expected value</Comment>
@@ -10869,6 +11779,9 @@
       </Method>
       <Method>
         <Name>AssertEquals_REAL</Name>
+        <Comment>
+    Asserts that two REALs are equal to within a positive delta. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expected</Name>
           <Comment> REAL expected value</Comment>
@@ -10906,6 +11819,9 @@
       </Method>
       <Method>
         <Name>AssertArrayEquals_SINT</Name>
+        <Comment>
+    Asserts that two SINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> SINT array with expected values</Comment>
@@ -10997,14 +11913,12 @@
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
-        <Local>
-          <Name>__Index__0</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
       </Method>
       <Method>
         <Name>AssertArrayEquals_UDINT</Name>
+        <Comment>
+    Asserts that two UDINT arrays are equal. If they are not, an assertion error is created.
+</Comment>
         <Parameter>
           <Name>Expecteds</Name>
           <Comment> UDINT array with expected values</Comment>
@@ -11093,11 +12007,6 @@
         </Local>
         <Local>
           <Name>ActualsIndex</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Local>
-        <Local>
-          <Name>__Index__0</Name>
           <Type>DINT</Type>
           <BitSize>32</BitSize>
         </Local>
@@ -11374,6 +12283,31 @@
       <Action>
         <Name>A_GetHead</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -11451,6 +12385,31 @@
         <BitSize>32</BitSize>
         <BitOffs>224</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -11516,12 +12475,23 @@
         </Default>
       </SubItem>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetLogCount</Name>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
         <Name>WriteLog</Name>
+        <Comment> Writes a new data set into the ring buffer </Comment>
         <Parameter>
           <Name>MsgCtrlMask</Name>
           <Type>DWORD</Type>
@@ -11557,6 +12527,7 @@
       </Method>
       <Method>
         <Name>GetAndRemoveLogFromQueue</Name>
+        <Comment> Reads and removes the oldest message </Comment>
         <Parameter>
           <Name>AdsLogStringMessage</Name>
           <Type Namespace="TcUnit">ST_AdsLogStringMessage</Type>
@@ -11579,6 +12550,21 @@
               <Value>Output</Value>
             </Property>
           </Properties>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Properties>
@@ -11715,7 +12701,7 @@
 	Pulse Timer.
 	Q produces a High-Signal with the length of PT on every rising edge on IN.
 </Comment>
-      <BitSize>224</BitSize>
+      <BitSize>256</BitSize>
       <SubItem>
         <Name>IN</Name>
         <Type>BOOL</Type>
@@ -11774,6 +12760,31 @@
         <BitSize>32</BitSize>
         <BitOffs>192</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -11783,7 +12794,7 @@
     </DataType>
     <DataType>
       <Name Namespace="PMPS">ST_FFOverride</Name>
-      <BitSize>768</BitSize>
+      <BitSize>832</BitSize>
       <SubItem>
         <Name>Duration</Name>
         <Type>DINT</Type>
@@ -11912,37 +12923,37 @@
       <SubItem>
         <Name>Timer</Name>
         <Type Namespace="Tc2_Standard">TP</Type>
-        <BitSize>224</BitSize>
+        <BitSize>256</BitSize>
         <BitOffs>256</BitOffs>
       </SubItem>
       <SubItem>
         <Name>OvrdActLogAck</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>480</BitOffs>
+        <BitOffs>512</BitOffs>
       </SubItem>
       <SubItem>
         <Name>OvrdExpLogAck</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>488</BitOffs>
+        <BitOffs>520</BitOffs>
       </SubItem>
       <SubItem>
         <Name>tOvrdActivate</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>512</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>576</BitOffs>
       </SubItem>
       <SubItem>
         <Name>tOvrdExpiring</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>640</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>704</BitOffs>
       </SubItem>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_Standard">RS</Name>
-      <BitSize>96</BitSize>
+      <BitSize>128</BitSize>
       <SubItem>
         <Name>SET</Name>
         <Type>BOOL</Type>
@@ -11981,6 +12992,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -11990,7 +13026,7 @@
     </DataType>
     <DataType>
       <Name Namespace="PMPS">ST_FF</Name>
-      <BitSize>8064</BitSize>
+      <BitSize>8128</BitSize>
       <SubItem>
         <Name>Info</Name>
         <Type Namespace="PMPS">ST_FFInfo</Type>
@@ -12008,7 +13044,7 @@
       <SubItem>
         <Name>Ovrd</Name>
         <Type Namespace="PMPS">ST_FFOverride</Type>
-        <BitSize>768</BitSize>
+        <BitSize>832</BitSize>
         <BitOffs>6848</BitOffs>
         <Properties>
           <Property>
@@ -12024,7 +13060,7 @@
         <Type>BOOL</Type>
         <Comment> Fault logic state</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>7616</BitOffs>
+        <BitOffs>7680</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -12040,20 +13076,20 @@
         <Type>BOOL</Type>
         <Comment> Set when faulted, reset by logger.</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>7624</BitOffs>
+        <BitOffs>7688</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ClearAck</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>7632</BitOffs>
+        <BitOffs>7696</BitOffs>
       </SubItem>
       <SubItem>
         <Name>BeamPermitted</Name>
         <Type>BOOL</Type>
         <Comment> Result of reset, veto, and fault logic, true beam off boolean</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>7640</BitOffs>
+        <BitOffs>7704</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -12068,7 +13104,7 @@
         <Name>Reset</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>7648</BitOffs>
+        <BitOffs>7712</BitOffs>
         <Properties>
           <Property>
             <Name>pytmc</Name>
@@ -12082,20 +13118,20 @@
       <SubItem>
         <Name>bsFF</Name>
         <Type Namespace="Tc2_Standard">RS</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>7680</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>7744</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtReset</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>7808</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>7872</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ftCountFault</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>7936</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>8000</BitOffs>
       </SubItem>
     </DataType>
     <DataType>
@@ -12117,6 +13153,7 @@
       <Name Namespace="Tc2_Utilities">E_TimeZoneID</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> Time zone identifier </Comment>
       <EnumInfo>
         <Text>eTimeZoneID_Invalid</Text>
         <Enum>-1</Enum>
@@ -12297,6 +13334,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -12427,6 +13489,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -12463,7 +13550,7 @@
     <DataType>
       <Name Namespace="Tc2_Utilities">FB_GetTimeZoneInformation</Name>
       <Comment> Reads time zone information </Comment>
-      <BitSize>3712</BitSize>
+      <BitSize>3776</BitSize>
       <SubItem>
         <Name>sNetID</Name>
         <Type Namespace="Tc2_System">T_AmsNetID</Type>
@@ -12594,7 +13681,7 @@
       <SubItem>
         <Name>fbTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>2688</BitOffs>
         <Properties>
           <Property>
@@ -12606,7 +13693,7 @@
         <Name>state</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>2784</BitOffs>
+        <BitOffs>2816</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -12617,13 +13704,38 @@
         <Name>res</Name>
         <Type Namespace="Tc2_Utilities">ST_AmsGetTimeZoneInformation</Type>
         <BitSize>896</BitSize>
-        <BitOffs>2816</BitOffs>
+        <BitOffs>2848</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -12787,6 +13899,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -12992,6 +14129,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13026,7 +14188,7 @@
     <DataType>
       <Name Namespace="Tc2_Utilities">FB_RegQueryValue</Name>
       <Comment> Reads windows registry value </Comment>
-      <BitSize>10880</BitSize>
+      <BitSize>10944</BitSize>
       <SubItem>
         <Name>sNetId</Name>
         <Type Namespace="Tc2_System">T_AmsNetID</Type>
@@ -13198,7 +14360,7 @@
       <SubItem>
         <Name>fbTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>6464</BitOffs>
         <Properties>
           <Property>
@@ -13210,7 +14372,7 @@
         <Name>state</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>6560</BitOffs>
+        <BitOffs>6592</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13221,7 +14383,7 @@
         <Name>s1Len</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>6592</BitOffs>
+        <BitOffs>6624</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13232,7 +14394,7 @@
         <Name>s2Len</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>6624</BitOffs>
+        <BitOffs>6656</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13243,7 +14405,7 @@
         <Name>ptr</Name>
         <Type PointerTo="1">BYTE</Type>
         <BitSize>64</BitSize>
-        <BitOffs>6656</BitOffs>
+        <BitOffs>6720</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13254,7 +14416,7 @@
         <Name>cbBuff</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>6720</BitOffs>
+        <BitOffs>6784</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13265,13 +14427,38 @@
         <Name>tmpBuff</Name>
         <Type Namespace="Tc2_Utilities">ST_HKeySrvRead</Type>
         <BitSize>4096</BitSize>
-        <BitOffs>6752</BitOffs>
+        <BitOffs>6816</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13284,7 +14471,7 @@
     </DataType>
     <DataType>
       <Name Namespace="Tc2_Utilities">NT_SetTimeToRTCTime</Name>
-      <BitSize>12800</BitSize>
+      <BitSize>12928</BitSize>
       <SubItem>
         <Name>NETID</Name>
         <Type Namespace="Tc2_System">T_AmsNetID</Type>
@@ -13391,7 +14578,7 @@
       <SubItem>
         <Name>fbRegQuery</Name>
         <Type Namespace="Tc2_Utilities">FB_RegQueryValue</Type>
-        <BitSize>10880</BitSize>
+        <BitSize>10944</BitSize>
         <BitOffs>1728</BitOffs>
         <Default>
           <SubItem>
@@ -13412,8 +14599,8 @@
       <SubItem>
         <Name>fbTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>12608</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>12672</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13424,7 +14611,7 @@
         <Name>bTmp</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
-        <BitOffs>12704</BitOffs>
+        <BitOffs>12800</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -13438,7 +14625,7 @@
         <Name>state</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>12736</BitOffs>
+        <BitOffs>12832</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -13452,7 +14639,7 @@
         <Name>bInit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>12744</BitOffs>
+        <BitOffs>12840</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
@@ -13466,7 +14653,7 @@
         <Name>numOfCPUs</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
-        <BitOffs>12768</BitOffs>
+        <BitOffs>12864</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -13476,6 +14663,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13513,6 +14725,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13567,6 +14804,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13580,7 +14842,7 @@
     <DataType>
       <Name Namespace="Tc2_Utilities">RTC_EX2</Name>
       <Comment> Software RTC (real time clock), returns time in structured system time format + microseconds (microsecond resolution) </Comment>
-      <BitSize>1024</BitSize>
+      <BitSize>1088</BitSize>
       <SubItem>
         <Name>EN</Name>
         <Type>BOOL</Type>
@@ -13691,7 +14953,7 @@
       <SubItem>
         <Name>risingEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>704</BitOffs>
         <Properties>
           <Property>
@@ -13703,7 +14965,7 @@
         <Name>oldTick</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
-        <BitOffs>800</BitOffs>
+        <BitOffs>832</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13714,7 +14976,7 @@
         <Name>currTick</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
-        <BitOffs>832</BitOffs>
+        <BitOffs>864</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13725,7 +14987,7 @@
         <Name>nanoDiff</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
-        <BitOffs>864</BitOffs>
+        <BitOffs>896</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13736,7 +14998,7 @@
         <Name>nanoRest</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
-        <BitOffs>896</BitOffs>
+        <BitOffs>928</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13747,7 +15009,7 @@
         <Name>secDiff</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
-        <BitOffs>928</BitOffs>
+        <BitOffs>960</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13758,7 +15020,7 @@
         <Name>dateTime</Name>
         <Type>DATE_AND_TIME</Type>
         <BitSize>32</BitSize>
-        <BitOffs>960</BitOffs>
+        <BitOffs>992</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13769,13 +15031,38 @@
         <Name>bInitialized</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>992</BitOffs>
+        <BitOffs>1024</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13789,7 +15076,7 @@
     <DataType>
       <Name Namespace="Tc2_Utilities">FB_LocalSystemTime</Name>
       <Comment> This function block synchronizes cyclically to and returns the Local Windows System Time. </Comment>
-      <BitSize>20480</BitSize>
+      <BitSize>20800</BitSize>
       <SubItem>
         <Name>sNetID</Name>
         <Type Namespace="Tc2_System">T_AmsNetID</Type>
@@ -13912,7 +15199,7 @@
       <SubItem>
         <Name>rtrig</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>576</BitOffs>
         <Properties>
           <Property>
@@ -13924,7 +15211,7 @@
         <Name>state</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>672</BitOffs>
+        <BitOffs>704</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13935,7 +15222,7 @@
         <Name>fbNT</Name>
         <Type Namespace="Tc2_Utilities">NT_GetTime</Type>
         <BitSize>1920</BitSize>
-        <BitOffs>704</BitOffs>
+        <BitOffs>768</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13945,8 +15232,8 @@
       <SubItem>
         <Name>fbTZ</Name>
         <Type Namespace="Tc2_Utilities">FB_GetTimeZoneInformation</Type>
-        <BitSize>3712</BitSize>
-        <BitOffs>2624</BitOffs>
+        <BitSize>3776</BitSize>
+        <BitOffs>2688</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13956,8 +15243,8 @@
       <SubItem>
         <Name>fbSET</Name>
         <Type Namespace="Tc2_Utilities">NT_SetTimeToRTCTime</Type>
-        <BitSize>12800</BitSize>
-        <BitOffs>6336</BitOffs>
+        <BitSize>12928</BitSize>
+        <BitOffs>6464</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13967,8 +15254,8 @@
       <SubItem>
         <Name>fbRTC</Name>
         <Type Namespace="Tc2_Utilities">RTC_EX2</Type>
-        <BitSize>1024</BitSize>
-        <BitOffs>19136</BitOffs>
+        <BitSize>1088</BitSize>
+        <BitOffs>19392</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13979,7 +15266,7 @@
         <Name>timer</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
         <BitSize>256</BitSize>
-        <BitOffs>20160</BitOffs>
+        <BitOffs>20480</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -13990,7 +15277,7 @@
         <Name>nSync</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
-        <BitOffs>20416</BitOffs>
+        <BitOffs>20736</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -14001,13 +15288,38 @@
         <Name>bNotSup</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>20448</BitOffs>
+        <BitOffs>20768</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -14289,6 +15601,31 @@
       <Action>
         <Name>A_Reset</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -14385,6 +15722,31 @@
       <Action>
         <Name>A_Reset</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -14593,7 +15955,23 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>ResetDocument</Name>
+        <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
@@ -14622,7 +16000,18 @@
         <ReturnBitSize>32</ReturnBitSize>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14699,8 +16088,8 @@
         </Parameter>
       </Method>
       <Method>
-        <Name RpcEnable="plc" VTableIndex="0">__get_ipWriter</Name>
-        <ReturnType GUID="{E695C12A-2D9A-408E-B9B2-508D7CE3AF9A}" RpcDirection="out">ITcJsonSaxWriter</ReturnType>
+        <Name>__get_ipWriter</Name>
+        <ReturnType GUID="{E695C12A-2D9A-408E-B9B2-508D7CE3AF9A}">ITcJsonSaxWriter</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Local>
           <Name>_ipWriter</Name>
@@ -14734,6 +16123,7 @@
       </Method>
       <Method>
         <Name>GetDocument</Name>
+        <Comment> | Returns the JSON document. If its size is more than 255 bytes the method CopyDocument() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
@@ -14809,6 +16199,7 @@
       </Method>
       <Method>
         <Name>CopyDocument</Name>
+        <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -14968,7 +16359,7 @@
     </DataType>
     <DataType>
       <Name Namespace="PMPS">FB_HardwareFFOutput</Name>
-      <BitSize>520576</BitSize>
+      <BitSize>524352</BitSize>
       <SubItem>
         <Name>FF_ARRAY_UPPER_BOUND</Name>
         <Type>UINT</Type>
@@ -15093,7 +16484,7 @@
           <LBound>1</LBound>
           <Elements>50</Elements>
         </ArrayInfo>
-        <BitSize>403200</BitSize>
+        <BitSize>406400</BitSize>
         <BitOffs>320</BitOffs>
         <Properties>
           <Property>
@@ -15109,7 +16500,7 @@
         <Type>BOOL</Type>
         <Comment> Set true if a fast fault fails to register. Holds beam off.</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>403520</BitOffs>
+        <BitOffs>406720</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15126,14 +16517,14 @@
       <SubItem>
         <Name>tFFRegFail</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>403584</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>406784</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sPath</Name>
         <Type Namespace="Tc2_System">T_MaxString</Type>
         <BitSize>2048</BitSize>
-        <BitOffs>403680</BitOffs>
+        <BitOffs>406912</BitOffs>
         <Properties>
           <Property>
             <Name>instance-path</Name>
@@ -15148,7 +16539,7 @@
         <Type>BOOL</Type>
         <Comment> Current internal state of FFO, indicates if FFO will accept a reset</Comment>
         <BitSize>8</BitSize>
-        <BitOffs>405728</BitOffs>
+        <BitOffs>408960</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
@@ -15165,20 +16556,20 @@
       <SubItem>
         <Name>rtReset</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>405760</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>409024</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtResetandOK</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>405888</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>409152</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nIndex</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>405984</BitOffs>
+        <BitOffs>409280</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
@@ -15187,14 +16578,14 @@
         <Name>IdxOK</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>406000</BitOffs>
+        <BitOffs>409296</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbTime</Name>
         <Type Namespace="Tc2_Utilities">FB_LocalSystemTime</Type>
         <Comment>Get current system time, used for override</Comment>
-        <BitSize>20480</BitSize>
-        <BitOffs>406016</BitOffs>
+        <BitSize>20800</BitSize>
+        <BitOffs>409344</BitOffs>
         <Default>
           <SubItem>
             <Name>.bEnable</Name>
@@ -15210,26 +16601,26 @@
         <Name>fbTime_to_UTC</Name>
         <Type Namespace="Tc2_Utilities">FB_TzSpecificLocalTimeToSystemTime</Type>
         <BitSize>3648</BitSize>
-        <BitOffs>426496</BitOffs>
+        <BitOffs>430144</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbGetTimeZone</Name>
         <Type Namespace="Tc2_Utilities">FB_GetTimeZoneInformation</Type>
-        <BitSize>3712</BitSize>
-        <BitOffs>430144</BitOffs>
+        <BitSize>3776</BitSize>
+        <BitOffs>433792</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbJson</Name>
         <Type Namespace="LCLS_General.Tc3_JsonXml">FB_JsonSaxWriter</Type>
         <BitSize>384</BitSize>
-        <BitOffs>433856</BitOffs>
+        <BitOffs>437568</BitOffs>
       </SubItem>
       <SubItem>
         <Name>pmpsTypeCode</Name>
         <Type>UDINT</Type>
         <Comment> shows up in json as pmps_typecode</Comment>
         <BitSize>32</BitSize>
-        <BitOffs>434240</BitOffs>
+        <BitOffs>437952</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -15237,8 +16628,8 @@
       <SubItem>
         <Name>fbLogger</Name>
         <Type Namespace="LCLS_General">FB_LogMessage</Type>
-        <BitSize>86016</BitSize>
-        <BitOffs>434304</BitOffs>
+        <BitSize>86080</BitSize>
+        <BitOffs>438016</BitOffs>
         <Default>
           <SubItem>
             <Name>.eSevr</Name>
@@ -15255,10 +16646,10 @@
         </Default>
       </SubItem>
       <SubItem>
-        <Name>__EXECUTELOGGING__HELLOTIMER</Name>
+        <Name>__FB_HARDWAREFFOUTPUT__EXECUTELOGGING__HELLOTIMER</Name>
         <Type Namespace="Tc2_Standard">TOF</Type>
         <BitSize>256</BitSize>
-        <BitOffs>520320</BitOffs>
+        <BitOffs>524096</BitOffs>
         <Default>
           <SubItem>
             <Name>.PT</Name>
@@ -15333,7 +16724,7 @@
           <Properties>
             <Property>
               <Name>uselocation</Name>
-              <Value>__EXECUTELOGGING__HELLOTIMER</Value>
+              <Value>__FB_HARDWAREFFOUTPUT__EXECUTELOGGING__HELLOTIMER</Value>
             </Property>
           </Properties>
         </Local>
@@ -15342,6 +16733,31 @@
             <Name>no_check</Name>
           </Property>
         </Properties>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
       </Method>
       <Method>
         <Name>Register</Name>
@@ -15402,7 +16818,7 @@
         <Local>
           <Name>stFF</Name>
           <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>8064</BitSize>
+          <BitSize>8128</BitSize>
         </Local>
         <Local>
           <Name>BeamPermitted</Name>
@@ -15422,7 +16838,7 @@
         <Parameter>
           <Name>FF</Name>
           <Type Namespace="PMPS">ST_FF</Type>
-          <BitSize>8064</BitSize>
+          <BitSize>8128</BitSize>
         </Parameter>
       </Method>
       <Properties>
@@ -15439,6 +16855,24 @@
       </Properties>
     </DataType>
     <DataType>
+      <Name GUID="{18071995-0000-0000-0000-000000000041}" TcBaseType="true" HideSubItems="true" CName="AmsNetId">AMSNETID</Name>
+      <BitSize>48</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000001}">BYTE</BaseType>
+      <ArrayInfo>
+        <LBound>0</LBound>
+        <Elements>6</Elements>
+      </ArrayInfo>
+      <Format>
+        <Printf>%d.%d.%d.%d.%d.%d</Printf>
+        <Parameter>[0]</Parameter>
+        <Parameter>[1]</Parameter>
+        <Parameter>[2]</Parameter>
+        <Parameter>[3]</Parameter>
+        <Parameter>[4]</Parameter>
+        <Parameter>[5]</Parameter>
+      </Format>
+    </DataType>
+    <DataType>
       <Name Namespace="Tc2_System">T_AmsNetIdArr</Name>
       <Comment> TwinCAT AMS netID address bytes. </Comment>
       <BitSize>48</BitSize>
@@ -15447,7 +16881,7 @@
     <DataType>
       <Name Namespace="Tc2_Utilities">FB_GetLocalAmsNetId</Name>
       <Comment> Reads the local AmsNetId (local TwinCAT-specific network address) </Comment>
-      <BitSize>11520</BitSize>
+      <BitSize>11584</BitSize>
       <SubItem>
         <Name>bExecute</Name>
         <Type>BOOL</Type>
@@ -15571,7 +17005,7 @@
       <SubItem>
         <Name>fbRegQueryValue</Name>
         <Type Namespace="Tc2_Utilities">FB_RegQueryValue</Type>
-        <BitSize>10880</BitSize>
+        <BitSize>10944</BitSize>
         <BitOffs>448</BitOffs>
         <Default>
           <SubItem>
@@ -15596,8 +17030,8 @@
       <SubItem>
         <Name>fbTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>11328</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>11392</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -15608,7 +17042,7 @@
         <Name>state</Name>
         <Type>BYTE</Type>
         <BitSize>8</BitSize>
-        <BitOffs>11424</BitOffs>
+        <BitOffs>11520</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
@@ -15619,13 +17053,38 @@
         <Name>tmpBytes</Name>
         <Type Namespace="Tc2_System">T_AmsNetIdArr</Type>
         <BitSize>48</BitSize>
-        <BitOffs>11432</BitOffs>
+        <BitOffs>11528</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -15694,6 +17153,7 @@
       </Method>
       <Method>
         <Name>HasMember</Name>
+        <Comment> returns TRUE if succeeded</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -15832,6 +17292,7 @@
       </Method>
       <Method>
         <Name>RemoveMemberByName</Name>
+        <Comment> returns TRUE if succeeded</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -16144,6 +17605,7 @@
       </Method>
       <Method>
         <Name>ClearArray</Name>
+        <Comment> returns TRUE if succeeded</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -16159,6 +17621,7 @@
       </Method>
       <Method>
         <Name>RemoveAllMembers</Name>
+        <Comment> returns TRUE if succeeded</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -16302,6 +17765,7 @@
       </Method>
       <Method>
         <Name>GetStringLength</Name>
+        <Comment>| Returns the size in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -16322,6 +17786,9 @@
       </Method>
       <Method>
         <Name>SaveDocumentToFile</Name>
+        <Comment> | Saves a JSON document to file.
+ | The asynchronous process is finished when the bExec reference input is set to FALSE.
+ | When the process is finished the method return value shows whether the process was successful or not.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -16411,6 +17878,7 @@
       </Method>
       <Method>
         <Name>CopyDocument</Name>
+        <Comment>| Copies the full DOM document and returns its size in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -16454,6 +17922,21 @@
         <Parameter>
           <Name>value</Name>
           <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -16540,6 +18023,8 @@
       </Method>
       <Method>
         <Name>CopyString</Name>
+        <Comment>| The function copies a string to the given buffer if the given buffer size is big enough.
+| It returns the number of copied bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -16601,6 +18086,7 @@
       </Method>
       <Method>
         <Name>GetJsonLength</Name>
+        <Comment>| Returns the size of the JSON document in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -16616,6 +18102,7 @@
       </Method>
       <Method>
         <Name>Swap</Name>
+        <Comment> returns TRUE if succeeded</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -16772,6 +18259,7 @@
       </Method>
       <Method>
         <Name>PopbackValue</Name>
+        <Comment> returns TRUE if succeeded</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -16814,6 +18302,9 @@
       </Method>
       <Method>
         <Name>LoadDocumentFromFile</Name>
+        <Comment> | Loads a JSON document from file.
+ | The asynchronous process is finished when the bExec reference input is set to FALSE.
+ | When the process is finished the method return value shows whether the process was successful or not.</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -16889,6 +18380,7 @@
       </Method>
       <Method>
         <Name>RemoveMember</Name>
+        <Comment> returns TRUE if succeeded</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -16909,6 +18401,7 @@
       </Method>
       <Method>
         <Name>RemoveArray</Name>
+        <Comment> returns TRUE if succeeded</Comment>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
         <Parameter>
@@ -17208,6 +18701,7 @@
       </Method>
       <Method>
         <Name>CopyJson</Name>
+        <Comment>| Copies the JSON document and returns its size in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Parameter>
@@ -17297,6 +18791,16 @@
         </Parameter>
       </Method>
       <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
         <Name>GetBool</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -17343,6 +18847,8 @@
       </Method>
       <Method>
         <Name>GetDocument</Name>
+        <Comment> | Returns the full DOM document. 
+ | If its size is more than 255 bytes an empty string is returned and the method CopyDocument() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Local>
@@ -17418,6 +18924,7 @@
       </Method>
       <Method>
         <Name>GetDocumentLength</Name>
+        <Comment>| Returns the size of the DOM document in bytes (including the null termination).</Comment>
         <ReturnType>UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Local>
@@ -17428,6 +18935,8 @@
       </Method>
       <Method>
         <Name>GetJson</Name>
+        <Comment>| Returns the JSON document. 
+| If its size is more than 255 bytes an empty string is returned and the method CopyJson() has to be used.</Comment>
         <ReturnType>STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Parameter>
@@ -17608,6 +19117,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -17626,6 +19160,7 @@
       <Name Namespace="Tc2_System">E_OpenPath</Name>
       <BitSize>16</BitSize>
       <BaseType>UINT</BaseType>
+      <Comment> File open path </Comment>
       <EnumInfo>
         <Text>PATH_GENERIC</Text>
         <Enum>1</Enum>
@@ -17695,7 +19230,7 @@
     <DataType>
       <Name Namespace="Tc2_System">FB_FileOpen</Name>
       <Comment> Open and/or create a file. </Comment>
-      <BitSize>3712</BitSize>
+      <BitSize>3776</BitSize>
       <SubItem>
         <Name>sNetId</Name>
         <Type Namespace="Tc2_System">T_AmsNetID</Type>
@@ -17832,6 +19367,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -17940,6 +19500,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -17953,7 +19538,7 @@
     <DataType>
       <Name Namespace="Tc2_System">FB_FileRead</Name>
       <Comment> Reads data from a stream. </Comment>
-      <BitSize>1792</BitSize>
+      <BitSize>1856</BitSize>
       <SubItem>
         <Name>sNetId</Name>
         <Type Namespace="Tc2_System">T_AmsNetID</Type>
@@ -18103,6 +19688,31 @@
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -18312,6 +19922,31 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>2048</BitSize>
         <BitOffs>23872</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -18324,7 +19959,7 @@ contributing fast faults, unless the FFO is currently vetoed.
     </DataType>
     <DataType>
       <Name Namespace="PMPS">FB_JsonFileToJsonDoc</Name>
-      <BitSize>935360</BitSize>
+      <BitSize>935616</BitSize>
       <SubItem>
         <Name>bExecute</Name>
         <Type>BOOL</Type>
@@ -18462,7 +20097,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>fb_GetLocalAmsNetId</Name>
         <Type Namespace="Tc2_Utilities">FB_GetLocalAmsNetId</Type>
         <Comment>Get AMS Net ID</Comment>
-        <BitSize>11520</BitSize>
+        <BitSize>11584</BitSize>
         <BitOffs>3904</BitOffs>
       </SubItem>
       <SubItem>
@@ -18470,45 +20105,45 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="LCLS_General.Tc3_JsonXml">FB_JsonDomParser</Type>
         <Comment> JSON </Comment>
         <BitSize>448</BitSize>
-        <BitOffs>15424</BitOffs>
+        <BitOffs>15488</BitOffs>
       </SubItem>
       <SubItem>
         <Name>jsonDoc</Name>
         <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
         <BitSize>64</BitSize>
-        <BitOffs>15872</BitOffs>
+        <BitOffs>15936</BitOffs>
       </SubItem>
       <SubItem>
         <Name>jsonProp</Name>
         <Type GUID="{928162FC-F0DF-42B8-9EC0-1494F07A4E2F}">SJsonValue</Type>
         <BitSize>64</BitSize>
-        <BitOffs>15936</BitOffs>
+        <BitOffs>16000</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbFileOpen</Name>
         <Type Namespace="Tc2_System">FB_FileOpen</Type>
         <Comment>File</Comment>
-        <BitSize>3712</BitSize>
-        <BitOffs>16000</BitOffs>
+        <BitSize>3776</BitSize>
+        <BitOffs>16064</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbFileClose</Name>
         <Type Namespace="Tc2_System">FB_FileClose</Type>
         <BitSize>1408</BitSize>
-        <BitOffs>19712</BitOffs>
+        <BitOffs>19840</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbFileRead</Name>
         <Type Namespace="Tc2_System">FB_FileRead</Type>
-        <BitSize>1792</BitSize>
-        <BitOffs>21120</BitOffs>
+        <BitSize>1856</BitSize>
+        <BitOffs>21248</BitOffs>
       </SubItem>
       <SubItem>
         <Name>hSrcFile</Name>
         <Type>UINT</Type>
         <Comment> File handle of the source file </Comment>
         <BitSize>16</BitSize>
-        <BitOffs>22912</BitOffs>
+        <BitOffs>23104</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -18517,32 +20152,32 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>Step</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>22928</BitOffs>
+        <BitOffs>23120</BitOffs>
       </SubItem>
       <SubItem>
         <Name>index</Name>
         <Type>DINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>22944</BitOffs>
+        <BitOffs>23136</BitOffs>
       </SubItem>
       <SubItem>
         <Name>RisingEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>22976</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>23168</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sbuffRead</Name>
         <Type>STRING(100000)</Type>
         <Comment> Buffer </Comment>
         <BitSize>800008</BitSize>
-        <BitOffs>23072</BitOffs>
+        <BitOffs>23296</BitOffs>
       </SubItem>
       <SubItem>
         <Name>cbReadLength</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>823104</BitOffs>
+        <BitOffs>823328</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -18551,7 +20186,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>nFileLength</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>823136</BitOffs>
+        <BitOffs>823360</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -18560,13 +20195,13 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bfbJsonExceptionRaised</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>823168</BitOffs>
+        <BitOffs>823392</BitOffs>
       </SubItem>
       <SubItem>
         <Name>tTimeOut</Name>
         <Type>TIME</Type>
         <BitSize>32</BitSize>
-        <BitOffs>823200</BitOffs>
+        <BitOffs>823424</BitOffs>
         <Default>
           <Value>5000</Value>
         </Default>
@@ -18575,20 +20210,20 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>bInit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>823232</BitOffs>
+        <BitOffs>823456</BitOffs>
       </SubItem>
       <SubItem>
         <Name>tNewMessage</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
         <Comment>Logger</Comment>
-        <BitSize>96</BitSize>
-        <BitOffs>823296</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>823488</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbLogger</Name>
         <Type Namespace="LCLS_General">FB_LogMessage</Type>
-        <BitSize>86016</BitSize>
-        <BitOffs>823424</BitOffs>
+        <BitSize>86080</BitSize>
+        <BitOffs>823616</BitOffs>
         <Default>
           <SubItem>
             <Name>.eSubsystem</Name>
@@ -18605,7 +20240,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Type Namespace="PMPS">FB_FastFault</Type>
         <Comment>FFO</Comment>
         <BitSize>25920</BitSize>
-        <BitOffs>909440</BitOffs>
+        <BitOffs>909696</BitOffs>
         <Default>
           <SubItem>
             <Name>.i_Desc</Name>
@@ -18623,6 +20258,31 @@ contributing fast faults, unless the FFO is currently vetoed.
       <Action>
         <Name>ACT_Logger</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -18632,7 +20292,7 @@ contributing fast faults, unless the FFO is currently vetoed.
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</Name>
-      <BitSize>29760</BitSize>
+      <BitSize>30144</BitSize>
       <SubItem>
         <Name>io_fbFFHWO</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
@@ -18727,34 +20387,46 @@ contributing fast faults, unless the FFO is currently vetoed.
         </Properties>
       </SubItem>
       <SubItem>
-        <Name>bExecute</Name>
+        <Name>bReadPmpsDb</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
         <BitOffs>1472</BitOffs>
+        <Properties>
+          <Property>
+            <Name>ItemType</Name>
+            <Value>Output</Value>
+          </Property>
+        </Properties>
+      </SubItem>
+      <SubItem>
+        <Name>bExecute</Name>
+        <Type>BOOL</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>1480</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtEnable</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>1536</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtRefresh</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>1664</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ftBusy</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>1792</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbTime</Name>
         <Type Namespace="Tc2_Utilities">FB_LocalSystemTime</Type>
         <Comment> Time tracking liften from Arbiter PLCs</Comment>
-        <BitSize>20480</BitSize>
+        <BitSize>20800</BitSize>
         <BitOffs>1920</BitOffs>
         <Default>
           <SubItem>
@@ -18771,14 +20443,39 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Name>fbTime_to_UTC</Name>
         <Type Namespace="Tc2_Utilities">FB_TzSpecificLocalTimeToSystemTime</Type>
         <BitSize>3648</BitSize>
-        <BitOffs>22400</BitOffs>
+        <BitOffs>22720</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbGetTimeZone</Name>
         <Type Namespace="Tc2_Utilities">FB_GetTimeZoneInformation</Type>
-        <BitSize>3712</BitSize>
-        <BitOffs>26048</BitOffs>
+        <BitSize>3776</BitSize>
+        <BitOffs>26368</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -19141,6 +20838,31 @@ contributing fast faults, unless the FFO is currently vetoed.
  Workaround for compile defines not fully working for libraries at the time of writing this.
  Otherwise I would have just used the compile define in the GVL declaration.</Comment>
       <BitSize>64</BitSize>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -20814,6 +22536,31 @@ contributing fast faults, unless the FFO is currently vetoed.
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -21114,6 +22861,31 @@ contributing fast faults, unless the FFO is currently vetoed.
       <Action>
         <Name>ReadDeviceInfo</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -21303,7 +23075,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Relations>
     </DataType>
     <DataType>
-      <Name GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
+      <Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
       <BitSize>32</BitSize>
       <SubItem>
         <Name>Operational</Name>
@@ -21414,6 +23186,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitOffs>17</BitOffs>
       </SubItem>
       <SubItem>
+        <Name>IsDriveLimitActive</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>18</BitOffs>
+      </SubItem>
+      <SubItem>
         <Name>ContinuousMotion</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
         <BitSize>1</BitSize>
@@ -21500,6 +23278,11 @@ contributing fast faults, unless the FFO is currently vetoed.
       <Format Name="IEC">
         <Printf>16#%08X</Printf>
       </Format>
+      <Relations>
+        <Relation Priority="100">
+          <Type>{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}</Type>
+        </Relation>
+      </Relations>
     </DataType>
     <DataType>
       <Name GUID="{6EF49753-C72C-4F50-AA44-3C7498E76CFE}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_OPMODE</Name>
@@ -21695,11 +23478,11 @@ contributing fast faults, unless the FFO is currently vetoed.
       </ArrayInfo>
     </DataType>
     <DataType>
-      <Name GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+      <Name GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
       <BitSize>2048</BitSize>
       <SubItem>
         <Name>StateDWord</Name>
-        <Type GUID="{4C3FC5AC-D5AA-44C6-AC5A-159774BA0F6D}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
+        <Type GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC">NCTOPLC_AXIS_REF_STATE</Type>
         <BitSize>32</BitSize>
         <BitOffs>0</BitOffs>
       </SubItem>
@@ -21948,6 +23731,18 @@ External Setpoint Generation:
         <BitOffs>1600</BitOffs>
       </SubItem>
       <SubItem>
+        <Name>AbsPhasingPos</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1664</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TorqueOffset</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1728</BitOffs>
+      </SubItem>
+      <SubItem>
         <Name>ActPosWithoutPosCorrection</Name>
         <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
         <BitSize>64</BitSize>
@@ -21993,6 +23788,9 @@ External Setpoint Generation:
         <Relation Priority="100">
           <Type GUID="{8CDE0C45-AB9D-42DB-BC94-1CF7521AB268}"/>
         </Relation>
+        <Relation Priority="100">
+          <Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}"/>
+        </Relation>
       </Relations>
     </DataType>
     <DataType>
@@ -22021,6 +23819,9 @@ External Setpoint Generation:
       <Name Namespace="Tc2_MC2">MC_AxisStates</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> 	PLCopen axis states
+	The axis states are defined in the PLCopen state diagram
+</Comment>
       <EnumInfo>
         <Text>MC_AXISSTATE_UNDEFINED</Text>
         <Enum>0</Enum>
@@ -22966,6 +24767,7 @@ External Setpoint Generation:
       <Name Namespace="Tc2_MC2">_E_PhasingState</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
+      <Comment> Phasing internal probe states </Comment>
       <EnumInfo>
         <Text>PhasingInactive</Text>
         <Enum>0</Enum>
@@ -22978,6 +24780,11 @@ External Setpoint Generation:
         <Text>PhasingAborted</Text>
         <Enum>2</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_InternalAxisRefData</Name>
@@ -23054,7 +24861,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>NcToPlc</Name>
-        <Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</Type>
+        <Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</Type>
         <BitSize>2048</BitSize>
         <BitOffs>1088</BitOffs>
         <Properties>
@@ -23133,6 +24940,31 @@ External Setpoint Generation:
       <Action>
         <Name>ReadStatus</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -23178,7 +25010,8 @@ External Setpoint Generation:
             <Value>
         pv: sFlagDesc
         io: i
-        field: DESC of nFlag variable, using </Value>
+        field: DESC semicolon-delimited nFlag variable
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -23229,6 +25062,14 @@ External Setpoint Generation:
         <Enum>2</Enum>
         <Comment> Enable before motion, disable after motion</Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">ENUM_StageBrakeMode</Name>
@@ -23249,6 +25090,14 @@ External Setpoint Generation:
         <Enum>2</Enum>
         <Comment> Do not change the brake state in FB_MotionStage</Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">ENUM_EpicsHomeCmd</Name>
@@ -23284,6 +25133,14 @@ External Setpoint Generation:
         <Enum>-1</Enum>
         <Comment> Do not home, ever</Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>qualified_only</Name>
+        </Property>
+        <Property>
+          <Name>strict</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">ST_AxisParameterSet</Name>
@@ -25069,6 +26926,31 @@ External Setpoint Generation:
         <BitSize>64</BitSize>
         <BitOffs>448</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -25189,6 +27071,11 @@ External Setpoint Generation:
         <Enum>18</Enum>
         <Comment> Verrechnete Winkelgeschwindigkeit fuer konstante Oberflaechengeschwindig. in Abhaengigkeit vom Radiusistwert des Enc.2 </Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">ST_GearInOptions</Name>
@@ -25276,6 +27163,11 @@ External Setpoint Generation:
         <Text>STATE_MOTIONCOMMANDSLOCKED</Text>
         <Enum>104</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_ST_TcNC_CoupleSlave</Name>
@@ -25625,6 +27517,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -25885,7 +27802,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbOnTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>6976</BitOffs>
         <Properties>
           <Property>
@@ -25910,6 +27827,31 @@ External Setpoint Generation:
       <Action>
         <Name>WriteGearRatio</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26055,7 +27997,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbOnTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>1728</BitOffs>
         <Properties>
           <Property>
@@ -26074,6 +28016,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26096,6 +28063,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26232,6 +28224,31 @@ External Setpoint Generation:
         <BitSize>128</BitSize>
         <BitOffs>10624</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26570,6 +28587,31 @@ External Setpoint Generation:
         <BitSize>10752</BitSize>
         <BitOffs>12544</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26769,6 +28811,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26885,7 +28952,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbOnTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>1792</BitOffs>
         <Properties>
           <Property>
@@ -26893,6 +28960,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -26906,7 +28998,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_Power</Name>
-      <BitSize>896</BitSize>
+      <BitSize>960</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -27083,7 +29175,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>EnableOffOnDelay</Name>
         <Type Namespace="Tc2_Standard">TP</Type>
-        <BitSize>224</BitSize>
+        <BitSize>256</BitSize>
         <BitOffs>640</BitOffs>
         <Properties>
           <Property>
@@ -27095,13 +29187,38 @@ External Setpoint Generation:
         <Name>iOverride</Name>
         <Type>DWORD</Type>
         <BitSize>32</BitSize>
-        <BitOffs>864</BitOffs>
+        <BitOffs>896</BitOffs>
         <Properties>
           <Property>
             <Name>conditionalshow</Name>
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -27262,6 +29379,11 @@ External Setpoint Generation:
         <Enum>12290</Enum>
         <Comment> 20190108 Fap - Start torque control relative NOT IMPLEMENTED </Comment>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>conditionalshow</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">ST_TorqueControlOptions</Name>
@@ -27559,7 +29681,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Name>
-      <BitSize>8448</BitSize>
+      <BitSize>8512</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -28082,38 +30204,38 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbOnTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>6016</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sTempMsg</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <BitOffs>6112</BitOffs>
+        <BitOffs>6144</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AccDecreasing</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>8160</BitOffs>
+        <BitOffs>8192</BitOffs>
       </SubItem>
       <SubItem>
         <Name>AccOld</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>8192</BitOffs>
+        <BitOffs>8256</BitOffs>
       </SubItem>
       <SubItem>
         <Name>iContinuousUpdate</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>8256</BitOffs>
+        <BitOffs>8320</BitOffs>
       </SubItem>
       <SubItem>
         <Name>OpMode</Name>
         <Type Namespace="Tc2_MC2">_ST_TcNc_OperationModes</Type>
         <BitSize>128</BitSize>
-        <BitOffs>8288</BitOffs>
+        <BitOffs>8352</BitOffs>
         <Properties>
           <Property>
             <Name>suppress_warning_0</Name>
@@ -28145,6 +30267,31 @@ External Setpoint Generation:
       <Action>
         <Name>ActNcCycleCounter</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -28157,7 +30304,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_Halt</Name>
-      <BitSize>9472</BitSize>
+      <BitSize>9536</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -28323,15 +30470,40 @@ External Setpoint Generation:
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>8448</BitSize>
+        <BitSize>8512</BitSize>
         <BitOffs>960</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>9408</BitOffs>
+        <BitOffs>9472</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -28396,7 +30568,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_MoveVelocity</Name>
-      <BitSize>9600</BitSize>
+      <BitSize>9664</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -28603,15 +30775,40 @@ External Setpoint Generation:
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>8448</BitSize>
+        <BitSize>8512</BitSize>
         <BitOffs>1088</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>9536</BitOffs>
+        <BitOffs>9600</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -28667,7 +30864,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_MoveAbsolute</Name>
-      <BitSize>9664</BitSize>
+      <BitSize>9728</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -28877,15 +31074,40 @@ External Setpoint Generation:
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>8448</BitSize>
+        <BitSize>8512</BitSize>
         <BitOffs>1152</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>9600</BitOffs>
+        <BitOffs>9664</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -28895,7 +31117,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_MoveRelative</Name>
-      <BitSize>9664</BitSize>
+      <BitSize>9728</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -29098,15 +31320,40 @@ External Setpoint Generation:
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>8448</BitSize>
+        <BitSize>8512</BitSize>
         <BitOffs>1152</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>9600</BitOffs>
+        <BitOffs>9664</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -29116,7 +31363,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_Jog</Name>
-      <BitSize>48512</BitSize>
+      <BitSize>48832</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -29329,122 +31576,122 @@ External Setpoint Generation:
       <SubItem>
         <Name>MoveVelocity</Name>
         <Type Namespace="Tc2_MC2">MC_MoveVelocity</Type>
-        <BitSize>9600</BitSize>
+        <BitSize>9664</BitSize>
         <BitOffs>768</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveVelocityOut</Name>
         <Type Namespace="Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>10368</BitOffs>
+        <BitOffs>10432</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Direction</Name>
         <Type Namespace="Tc2_MC2">MC_Direction</Type>
         <BitSize>16</BitSize>
-        <BitOffs>10464</BitOffs>
+        <BitOffs>10528</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ExecuteHalt</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>10480</BitOffs>
+        <BitOffs>10544</BitOffs>
       </SubItem>
       <SubItem>
         <Name>Halt</Name>
         <Type Namespace="Tc2_MC2">MC_Halt</Type>
-        <BitSize>9472</BitSize>
-        <BitOffs>10496</BitOffs>
+        <BitSize>9536</BitSize>
+        <BitOffs>10560</BitOffs>
       </SubItem>
       <SubItem>
         <Name>HaltOut</Name>
         <Type Namespace="Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>19968</BitOffs>
+        <BitOffs>20096</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ExecuteMoveAbsolute</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>20064</BitOffs>
+        <BitOffs>20192</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveAbsolute</Name>
         <Type Namespace="Tc2_MC2">MC_MoveAbsolute</Type>
-        <BitSize>9664</BitSize>
-        <BitOffs>20096</BitOffs>
+        <BitSize>9728</BitSize>
+        <BitOffs>20224</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveAbsoluteOut</Name>
         <Type Namespace="Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>29760</BitOffs>
+        <BitOffs>29952</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ExecuteMoveRelative</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>29856</BitOffs>
+        <BitOffs>30048</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveRelative</Name>
         <Type Namespace="Tc2_MC2">MC_MoveRelative</Type>
-        <BitSize>9664</BitSize>
-        <BitOffs>29888</BitOffs>
+        <BitSize>9728</BitSize>
+        <BitOffs>30080</BitOffs>
       </SubItem>
       <SubItem>
         <Name>MoveRelativeOut</Name>
         <Type Namespace="Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>39552</BitOffs>
+        <BitOffs>39808</BitOffs>
       </SubItem>
       <SubItem>
         <Name>JogMove</Name>
         <Type Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>8448</BitSize>
-        <BitOffs>39680</BitOffs>
+        <BitSize>8512</BitSize>
+        <BitOffs>39936</BitOffs>
       </SubItem>
       <SubItem>
         <Name>LastJogMoveResult</Name>
         <Type Namespace="Tc2_MC2">_ST_FunctionBlockResults</Type>
         <BitSize>96</BitSize>
-        <BitOffs>48128</BitOffs>
+        <BitOffs>48448</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ExecuteJogMove</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>48224</BitOffs>
+        <BitOffs>48544</BitOffs>
       </SubItem>
       <SubItem>
         <Name>StartType</Name>
         <Type Namespace="Tc2_MC2">_E_TcNC_StartPosType</Type>
         <BitSize>16</BitSize>
-        <BitOffs>48240</BitOffs>
+        <BitOffs>48560</BitOffs>
       </SubItem>
       <SubItem>
         <Name>JogMoveOut</Name>
         <Type Namespace="Tc2_MC2">ST_McOutputs</Type>
         <BitSize>96</BitSize>
-        <BitOffs>48256</BitOffs>
+        <BitOffs>48576</BitOffs>
       </SubItem>
       <SubItem>
         <Name>JogEnd</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>48352</BitOffs>
+        <BitOffs>48672</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TargetPosition</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>48384</BitOffs>
+        <BitOffs>48704</BitOffs>
       </SubItem>
       <SubItem>
         <Name>modulo</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>48448</BitOffs>
+        <BitOffs>48768</BitOffs>
       </SubItem>
       <Action>
         <Name>ActJogMove</Name>
@@ -29452,6 +31699,31 @@ External Setpoint Generation:
       <Action>
         <Name>ActCheckJogEnd</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -29461,7 +31733,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_MoveModulo</Name>
-      <BitSize>9792</BitSize>
+      <BitSize>9856</BitSize>
       <SubItem>
         <Name>Axis</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">AXIS_REF</Type>
@@ -29676,30 +31948,55 @@ External Setpoint Generation:
       <SubItem>
         <Name>MoveGeneric</Name>
         <Type Namespace="Tc2_MC2">_FB_MoveUniversalGeneric</Type>
-        <BitSize>8448</BitSize>
+        <BitSize>8512</BitSize>
         <BitOffs>1152</BitOffs>
       </SubItem>
       <SubItem>
         <Name>StartType</Name>
         <Type Namespace="Tc2_MC2">_E_TcNC_StartPosType</Type>
         <BitSize>16</BitSize>
-        <BitOffs>9600</BitOffs>
+        <BitOffs>9664</BitOffs>
       </SubItem>
       <SubItem>
         <Name>CmdNo</Name>
         <Type>UINT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>9616</BitOffs>
+        <BitOffs>9680</BitOffs>
       </SubItem>
       <SubItem>
         <Name>TriggerExecute</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>9664</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>9728</BitOffs>
       </SubItem>
       <Action>
         <Name>MC_MoveModuloCall</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -30074,7 +32371,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbOnTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>2112</BitOffs>
         <Properties>
           <Property>
@@ -30082,6 +32379,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -30429,7 +32751,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbTrigger</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>7680</BitOffs>
         <Properties>
           <Property>
@@ -30448,6 +32770,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -30582,6 +32929,31 @@ External Setpoint Generation:
         <BitSize>1344</BitSize>
         <BitOffs>384</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -30713,6 +33085,31 @@ External Setpoint Generation:
         <BitSize>1344</BitSize>
         <BitOffs>448</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -30858,7 +33255,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>384</BitOffs>
       </SubItem>
       <SubItem>
@@ -30873,6 +33270,31 @@ External Setpoint Generation:
         <BitSize>1792</BitSize>
         <BitOffs>2304</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31119,9 +33541,34 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbRTrigg</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>17920</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31270,6 +33717,31 @@ External Setpoint Generation:
         <BitSize>8064</BitSize>
         <BitOffs>384</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31401,6 +33873,31 @@ External Setpoint Generation:
         <BitSize>1408</BitSize>
         <BitOffs>384</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31561,6 +34058,31 @@ External Setpoint Generation:
         <BitSize>1792</BitSize>
         <BitOffs>2112</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31712,7 +34234,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>256</BitOffs>
       </SubItem>
       <SubItem>
@@ -31727,6 +34249,31 @@ External Setpoint Generation:
         <BitSize>1728</BitSize>
         <BitOffs>2112</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31858,6 +34405,31 @@ External Setpoint Generation:
         <BitSize>1408</BitSize>
         <BitOffs>448</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -32012,6 +34584,31 @@ External Setpoint Generation:
         <BitSize>1856</BitSize>
         <BitOffs>2240</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -32021,7 +34618,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_HomePrepare</Name>
-      <BitSize>20480</BitSize>
+      <BitSize>20544</BitSize>
       <SubItem>
         <Name>En</Name>
         <Type>BOOL</Type>
@@ -32230,14 +34827,14 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>20352</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecuteReadNC</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>20448</BitOffs>
+        <BitOffs>20480</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -32246,7 +34843,7 @@ External Setpoint Generation:
         <Name>bExecuteWriteNC</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>20456</BitOffs>
+        <BitOffs>20488</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -32255,11 +34852,36 @@ External Setpoint Generation:
         <Name>nState</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>20464</BitOffs>
+        <BitOffs>20496</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -32269,7 +34891,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_HomeFinish</Name>
-      <BitSize>4224</BitSize>
+      <BitSize>4288</BitSize>
       <SubItem>
         <Name>En</Name>
         <Type>BOOL</Type>
@@ -32429,14 +35051,14 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>4096</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecuteWriteNC</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>4192</BitOffs>
+        <BitOffs>4224</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -32445,11 +35067,36 @@ External Setpoint Generation:
         <Name>nState</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>4208</BitOffs>
+        <BitOffs>4240</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -32459,7 +35106,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_HomeVirtual</Name>
-      <BitSize>61504</BitSize>
+      <BitSize>61760</BitSize>
       <SubItem>
         <Name>En</Name>
         <Type>BOOL</Type>
@@ -32668,32 +35315,32 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbMoveVelocity</Name>
         <Type Namespace="Tc2_MC2">MC_MoveVelocity</Type>
-        <BitSize>9600</BitSize>
+        <BitSize>9664</BitSize>
         <BitOffs>27008</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbHomePrepare</Name>
         <Type Namespace="lcls_twincat_motion">FB_HomePrepare</Type>
-        <BitSize>20480</BitSize>
-        <BitOffs>36608</BitOffs>
+        <BitSize>20544</BitSize>
+        <BitOffs>36672</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbHomeFinish</Name>
         <Type Namespace="lcls_twincat_motion">FB_HomeFinish</Type>
-        <BitSize>4224</BitSize>
-        <BitOffs>57088</BitOffs>
+        <BitSize>4288</BitSize>
+        <BitOffs>57216</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>61312</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>61504</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nHomingState</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>61408</BitOffs>
+        <BitOffs>61632</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -32702,7 +35349,7 @@ External Setpoint Generation:
         <Name>bExecuteHomeToSwitch</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>61424</BitOffs>
+        <BitOffs>61648</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -32711,7 +35358,7 @@ External Setpoint Generation:
         <Name>bExecuteMoveVelocity</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>61432</BitOffs>
+        <BitOffs>61656</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -32720,7 +35367,7 @@ External Setpoint Generation:
         <Name>bExecutePrepare</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>61440</BitOffs>
+        <BitOffs>61664</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -32729,7 +35376,7 @@ External Setpoint Generation:
         <Name>bExecuteFinish</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>61448</BitOffs>
+        <BitOffs>61672</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -32738,20 +35385,20 @@ External Setpoint Generation:
         <Name>bExecuteHomeDirect</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>61456</BitOffs>
+        <BitOffs>61680</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nCmdDataLocal</Name>
         <Type>UINT</Type>
         <Comment>Ensure that nCmdData is not changed during sequence</Comment>
         <BitSize>16</BitSize>
-        <BitOffs>61472</BitOffs>
+        <BitOffs>61696</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bSequenceReady</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>61488</BitOffs>
+        <BitOffs>61712</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
@@ -32760,11 +35407,36 @@ External Setpoint Generation:
         <Name>bRestoreNCDataNeeded</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>61496</BitOffs>
+        <BitOffs>61720</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -32774,7 +35446,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_DriveVirtual</Name>
-      <BitSize>180864</BitSize>
+      <BitSize>181824</BitSize>
       <SubItem>
         <Name>sVersion</Name>
         <Type>STRING(80)</Type>
@@ -33238,75 +35910,100 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbPower</Name>
         <Type Namespace="Tc2_MC2">MC_Power</Type>
-        <BitSize>896</BitSize>
+        <BitSize>960</BitSize>
         <BitOffs>14336</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbHalt</Name>
         <Type Namespace="Tc2_MC2">MC_Halt</Type>
-        <BitSize>9472</BitSize>
-        <BitOffs>15232</BitOffs>
+        <BitSize>9536</BitSize>
+        <BitOffs>15296</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbJog</Name>
         <Type Namespace="Tc2_MC2">MC_Jog</Type>
-        <BitSize>48512</BitSize>
-        <BitOffs>24704</BitOffs>
+        <BitSize>48832</BitSize>
+        <BitOffs>24832</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMoveVelocity</Name>
         <Type Namespace="Tc2_MC2">MC_MoveVelocity</Type>
-        <BitSize>9600</BitSize>
-        <BitOffs>73216</BitOffs>
+        <BitSize>9664</BitSize>
+        <BitOffs>73664</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMoveRelative</Name>
         <Type Namespace="Tc2_MC2">MC_MoveRelative</Type>
-        <BitSize>9664</BitSize>
-        <BitOffs>82816</BitOffs>
+        <BitSize>9728</BitSize>
+        <BitOffs>83328</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMoveAbsolute</Name>
         <Type Namespace="Tc2_MC2">MC_MoveAbsolute</Type>
-        <BitSize>9664</BitSize>
-        <BitOffs>92480</BitOffs>
+        <BitSize>9728</BitSize>
+        <BitOffs>93056</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMoveModulo</Name>
         <Type Namespace="Tc2_MC2">MC_MoveModulo</Type>
-        <BitSize>9792</BitSize>
-        <BitOffs>102144</BitOffs>
+        <BitSize>9856</BitSize>
+        <BitOffs>102784</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbHomeVirtual</Name>
         <Type Namespace="lcls_twincat_motion">FB_HomeVirtual</Type>
-        <BitSize>61504</BitSize>
-        <BitOffs>111936</BitOffs>
+        <BitSize>61760</BitSize>
+        <BitOffs>112640</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbGearInDyn</Name>
         <Type Namespace="Tc2_MC2">MC_GearInDyn</Type>
         <BitSize>4416</BitSize>
-        <BitOffs>173440</BitOffs>
+        <BitOffs>174400</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbGearOut</Name>
         <Type Namespace="Tc2_MC2">MC_GearOut</Type>
         <BitSize>2112</BitSize>
-        <BitOffs>177856</BitOffs>
+        <BitOffs>178816</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbExecuteRiseEdge</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>179968</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>180928</BitOffs>
       </SubItem>
       <SubItem>
         <Name>stAxisStatus</Name>
         <Type Namespace="lcls_twincat_motion">DUT_AxisStatus_v0_01</Type>
         <BitSize>768</BitSize>
-        <BitOffs>180096</BitOffs>
+        <BitOffs>181056</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33316,7 +36013,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_MotionHoming</Name>
-      <BitSize>51584</BitSize>
+      <BitSize>51904</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
@@ -33398,26 +36095,26 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbJog</Name>
         <Type Namespace="Tc2_MC2">MC_Jog</Type>
-        <BitSize>48512</BitSize>
+        <BitSize>48832</BitSize>
         <BitOffs>2432</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtExec</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>50944</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>51264</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ftExec</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>51072</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>51392</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nHomeStateMachine</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>51168</BitOffs>
+        <BitOffs>51520</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -33426,49 +36123,49 @@ External Setpoint Generation:
         <Name>nStateAfterStop</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>51184</BitOffs>
+        <BitOffs>51536</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nMoves</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>51200</BitOffs>
+        <BitOffs>51552</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bFirstDirection</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>51216</BitOffs>
+        <BitOffs>51568</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bAtHome</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>51224</BitOffs>
+        <BitOffs>51576</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bMove</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>51232</BitOffs>
+        <BitOffs>51584</BitOffs>
       </SubItem>
       <SubItem>
         <Name>nErrCount</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>51248</BitOffs>
+        <BitOffs>51600</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bInterrupted</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>51264</BitOffs>
+        <BitOffs>51616</BitOffs>
       </SubItem>
       <SubItem>
         <Name>IDLE</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>51280</BitOffs>
+        <BitOffs>51632</BitOffs>
         <Default>
           <Value>0</Value>
         </Default>
@@ -33477,7 +36174,7 @@ External Setpoint Generation:
         <Name>NEXT_MOVE</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>51296</BitOffs>
+        <BitOffs>51648</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
@@ -33486,7 +36183,7 @@ External Setpoint Generation:
         <Name>CHECK_FWD</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>51312</BitOffs>
+        <BitOffs>51664</BitOffs>
         <Default>
           <Value>2</Value>
         </Default>
@@ -33495,7 +36192,7 @@ External Setpoint Generation:
         <Name>CHECK_BWD</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>51328</BitOffs>
+        <BitOffs>51680</BitOffs>
         <Default>
           <Value>3</Value>
         </Default>
@@ -33504,7 +36201,7 @@ External Setpoint Generation:
         <Name>FINAL_MOVE</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>51344</BitOffs>
+        <BitOffs>51696</BitOffs>
         <Default>
           <Value>4</Value>
         </Default>
@@ -33513,7 +36210,7 @@ External Setpoint Generation:
         <Name>FINAL_SETPOS</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>51360</BitOffs>
+        <BitOffs>51712</BitOffs>
         <Default>
           <Value>5</Value>
         </Default>
@@ -33522,7 +36219,7 @@ External Setpoint Generation:
         <Name>ERROR</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>51376</BitOffs>
+        <BitOffs>51728</BitOffs>
         <Default>
           <Value>6</Value>
         </Default>
@@ -33531,7 +36228,7 @@ External Setpoint Generation:
         <Name>WAIT_STOP</Name>
         <Type>INT</Type>
         <BitSize>16</BitSize>
-        <BitOffs>51392</BitOffs>
+        <BitOffs>51744</BitOffs>
         <Default>
           <Value>7</Value>
         </Default>
@@ -33548,7 +36245,7 @@ External Setpoint Generation:
         rather than a silent failure of the soft limit marks.
     </Comment>
         <BitSize>64</BitSize>
-        <BitOffs>51456</BitOffs>
+        <BitOffs>51776</BitOffs>
         <Default>
           <Value>-99999999</Value>
         </Default>
@@ -33557,11 +36254,36 @@ External Setpoint Generation:
         <Name>BWD_START</Name>
         <Type>LREAL</Type>
         <BitSize>64</BitSize>
-        <BitOffs>51520</BitOffs>
+        <BitOffs>51840</BitOffs>
         <Default>
           <Value>99999999</Value>
         </Default>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33693,6 +36415,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33702,7 +36449,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_LogMotionError</Name>
-      <BitSize>87360</BitSize>
+      <BitSize>87488</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
@@ -33730,33 +36477,58 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbLogMessage</Name>
         <Type Namespace="LCLS_General">FB_LogMessage</Type>
-        <BitSize>86016</BitSize>
+        <BitSize>86080</BitSize>
         <BitOffs>192</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtNewError</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>86208</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>86272</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bChangedError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>86304</BitOffs>
+        <BitOffs>86400</BitOffs>
       </SubItem>
       <SubItem>
         <Name>sPrevErr</Name>
         <Type>STRING(80)</Type>
         <BitSize>648</BitSize>
-        <BitOffs>86312</BitOffs>
+        <BitOffs>86408</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbJson</Name>
         <Type Namespace="LCLS_General.Tc3_JsonXml">FB_JsonSaxWriter</Type>
         <BitSize>384</BitSize>
-        <BitOffs>86976</BitOffs>
+        <BitOffs>87104</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33779,6 +36551,31 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33788,7 +36585,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_ReadParameterSet</Name>
-      <BitSize>1920</BitSize>
+      <BitSize>1984</BitSize>
       <SubItem>
         <Name>Parameter</Name>
         <Type Namespace="Tc2_MC2" ReferenceTo="true">ST_AxisParameterSet</Type>
@@ -33881,14 +36678,14 @@ External Setpoint Generation:
       <SubItem>
         <Name>TriggerExecute</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
+        <BitSize>128</BitSize>
         <BitOffs>256</BitOffs>
       </SubItem>
       <SubItem>
         <Name>state</Name>
         <Type Namespace="Tc2_MC2">_E_TcMC_STATES</Type>
         <BitSize>16</BitSize>
-        <BitOffs>352</BitOffs>
+        <BitOffs>384</BitOffs>
         <Default>
           <Value>100</Value>
         </Default>
@@ -33897,23 +36694,48 @@ External Setpoint Generation:
         <Name>fbAdsRead</Name>
         <Type Namespace="Tc2_System">ADSREAD</Type>
         <BitSize>1408</BitSize>
-        <BitOffs>384</BitOffs>
+        <BitOffs>448</BitOffs>
       </SubItem>
       <SubItem>
         <Name>SizeofPayloadData</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>1792</BitOffs>
+        <BitOffs>1856</BitOffs>
       </SubItem>
       <SubItem>
         <Name>SizeofPayloadData64</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <BitOffs>1856</BitOffs>
+        <BitOffs>1920</BitOffs>
       </SubItem>
       <Action>
         <Name>ActGetSizeOfParameterSet</Name>
       </Action>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33923,7 +36745,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_MotionStageNCParams</Name>
-      <BitSize>2496</BitSize>
+      <BitSize>2560</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
@@ -33975,20 +36797,20 @@ External Setpoint Generation:
       <SubItem>
         <Name>mcReadParams</Name>
         <Type Namespace="Tc2_MC2">MC_ReadParameterSet</Type>
-        <BitSize>1920</BitSize>
+        <BitSize>1984</BitSize>
         <BitOffs>256</BitOffs>
       </SubItem>
       <SubItem>
         <Name>timer</Name>
         <Type Namespace="Tc2_Standard">TON</Type>
         <BitSize>256</BitSize>
-        <BitOffs>2176</BitOffs>
+        <BitOffs>2240</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecute</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>2432</BitOffs>
+        <BitOffs>2496</BitOffs>
         <Default>
           <Value>1</Value>
         </Default>
@@ -33997,8 +36819,33 @@ External Setpoint Generation:
         <Name>nLatchErrId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <BitOffs>2464</BitOffs>
+        <BitOffs>2528</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -34008,7 +36855,7 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="lcls_twincat_motion">FB_MotionStage</Name>
-      <BitSize>327040</BitSize>
+      <BitSize>328512</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
         <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
@@ -34024,147 +36871,172 @@ External Setpoint Generation:
       <SubItem>
         <Name>fbDriveVirtual</Name>
         <Type Namespace="lcls_twincat_motion">FB_DriveVirtual</Type>
-        <BitSize>180864</BitSize>
+        <BitSize>181824</BitSize>
         <BitOffs>128</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbMotionHome</Name>
         <Type Namespace="lcls_twincat_motion">FB_MotionHoming</Type>
-        <BitSize>51584</BitSize>
-        <BitOffs>180992</BitOffs>
+        <BitSize>51904</BitSize>
+        <BitOffs>181952</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbSaveRestore</Name>
         <Type Namespace="lcls_twincat_motion">FB_EncSaveRestore</Type>
         <BitSize>3264</BitSize>
-        <BitOffs>232576</BitOffs>
+        <BitOffs>233856</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbLogError</Name>
         <Type Namespace="lcls_twincat_motion">FB_LogMotionError</Type>
-        <BitSize>87360</BitSize>
-        <BitOffs>235840</BitOffs>
+        <BitSize>87488</BitSize>
+        <BitOffs>237120</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecute</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>323200</BitOffs>
+        <BitOffs>324608</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecMove</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>323208</BitOffs>
+        <BitOffs>324616</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bExecHome</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>323216</BitOffs>
+        <BitOffs>324624</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bFwdHit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>323224</BitOffs>
+        <BitOffs>324632</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bBwdHit</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>323232</BitOffs>
+        <BitOffs>324640</BitOffs>
       </SubItem>
       <SubItem>
         <Name>ftExec</Name>
         <Type Namespace="Tc2_Standard">F_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>323264</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>324672</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtExec</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>323392</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>324800</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtUserExec</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>323520</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>324928</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtTarget</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>323648</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>325056</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtHomed</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>323776</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>325184</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbSetEnables</Name>
         <Type Namespace="lcls_twincat_motion">FB_SetEnables</Type>
         <BitSize>128</BitSize>
-        <BitOffs>323904</BitOffs>
+        <BitOffs>325312</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bPosGoal</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>324032</BitOffs>
+        <BitOffs>325440</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bNegGoal</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>324040</BitOffs>
+        <BitOffs>325448</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbEncoderValue</Name>
         <Type Namespace="lcls_twincat_motion">FB_EncoderValue</Type>
         <BitSize>128</BitSize>
-        <BitOffs>324096</BitOffs>
+        <BitOffs>325504</BitOffs>
       </SubItem>
       <SubItem>
         <Name>fbNCParams</Name>
         <Type Namespace="lcls_twincat_motion">FB_MotionStageNCParams</Type>
-        <BitSize>2496</BitSize>
-        <BitOffs>324224</BitOffs>
+        <BitSize>2560</BitSize>
+        <BitOffs>325632</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bNewMoveReq</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>326720</BitOffs>
+        <BitOffs>328192</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bPrepareDisable</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>326728</BitOffs>
+        <BitOffs>328200</BitOffs>
       </SubItem>
       <SubItem>
         <Name>bMoveCmd</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <BitOffs>326736</BitOffs>
+        <BitOffs>328208</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtMoveCmdShortcut</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>326784</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>328256</BitOffs>
       </SubItem>
       <SubItem>
         <Name>rtHomeCmdShortcut</Name>
         <Type Namespace="Tc2_Standard">R_TRIG</Type>
-        <BitSize>96</BitSize>
-        <BitOffs>326912</BitOffs>
+        <BitSize>128</BitSize>
+        <BitOffs>328384</BitOffs>
       </SubItem>
+      <Method>
+        <Name>__GetInterfacePointer</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
+      <Method>
+        <Name>__GetInterfaceReference</Name>
+        <ReturnType>BOOL</ReturnType>
+        <ReturnBitSize>8</ReturnBitSize>
+        <Parameter>
+          <Name>nInterfaceId</Name>
+          <Type>DINT</Type>
+          <BitSize>32</BitSize>
+        </Parameter>
+        <Parameter>
+          <Name>pRef</Name>
+          <Type PointerTo="2">DWORD</Type>
+          <BitSize>64</BitSize>
+        </Parameter>
+      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -34536,7 +37408,24 @@ External Setpoint Generation:
       </SubItem>
     </DataType>
     <DataType>
-      <Name GUID="{5C8FF47F-7F83-4493-8D21-F1FF8A08F75A}" Namespace="PLC" TcBaseType="true">PlcAppSystemInfo</Name>
+      <Name GUID="{4591E628-DBCE-4E33-AE0B-7EB853AA256E}" Namespace="PLC" TcBaseType="true">EPlcPersistentStatus</Name>
+      <BitSize>8</BitSize>
+      <BaseType GUID="{18071995-0000-0000-0000-000000000002}">USINT</BaseType>
+      <EnumInfo>
+        <Text>PS_None</Text>
+        <Enum>0</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PS_All</Text>
+        <Enum>1</Enum>
+      </EnumInfo>
+      <EnumInfo>
+        <Text>PS_Partial</Text>
+        <Enum>2</Enum>
+      </EnumInfo>
+    </DataType>
+    <DataType>
+      <Name GUID="{941FDF6E-37CE-4C30-AA23-3236AFA461E2}" Namespace="PLC" TcBaseType="true">PlcAppSystemInfo</Name>
       <BitSize>2048</BitSize>
       <SubItem>
         <Name>ObjId</Name>
@@ -34617,6 +37506,12 @@ External Setpoint Generation:
         <BitOffs>224</BitOffs>
       </SubItem>
       <SubItem>
+        <Name>PersistentStatus</Name>
+        <Type GUID="{4591E628-DBCE-4E33-AE0B-7EB853AA256E}" Namespace="PLC">EPlcPersistentStatus</Type>
+        <BitSize>8</BitSize>
+        <BitOffs>232</BitOffs>
+      </SubItem>
+      <SubItem>
         <Name>TComSrvPtr</Name>
         <Type GUID="{00000030-0000-0000-E000-000000000064}">ITComObjectServer</Type>
         <BitSize X64="64">32</BitSize>
@@ -34644,6 +37539,7 @@ External Setpoint Generation:
         <Hide GUID="{5DCEB2BC-E196-43AD-80B7-EBACF31A430B}"/>
         <Hide GUID="{1B9FDDE4-B3B7-4F0F-AB14-24EDC2F643E7}"/>
         <Hide GUID="{C1C52E30-BC0B-44CA-BF39-E2FE7F2D145C}"/>
+        <Hide GUID="{5C8FF47F-7F83-4493-8D21-F1FF8A08F75A}"/>
       </Hides>
     </DataType>
     <DataType>
@@ -34746,6 +37642,14 @@ External Setpoint Generation:
         <Text>_implicit_freewheeling</Text>
         <Enum>3</Enum>
       </EnumInfo>
+      <Properties>
+        <Property>
+          <Name>hide</Name>
+        </Property>
+        <Property>
+          <Name>generate_implicit_init_function</Name>
+        </Property>
+      </Properties>
     </DataType>
     <DataType>
       <Name>_Implicit_Jitter_Distribution</Name>
@@ -35015,24 +37919,7 @@ External Setpoint Generation:
           <AreaNo AreaType="InputDst" CreateSymbols="true">0</AreaNo>
           <Name>PlcTask Inputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>80347136</ByteSize>
-          <Symbol>
-            <Name>LCLS_General.DefaultGlobals.stSys.I_EcatMaster1</Name>
-            <Comment> AMS Net ID used for FB_EcatDiag, among others </Comment>
-            <BitSize>48</BitSize>
-            <BaseType GUID="{18071995-0000-0000-0000-000000000041}">AMSNETID</BaseType>
-            <Properties>
-              <Property>
-                <Name>naming</Name>
-                <Value>omit</Value>
-              </Property>
-              <Property>
-                <Name>TcAddressType</Name>
-                <Value>Input</Value>
-              </Property>
-            </Properties>
-            <BitOffs>4096040</BitOffs>
-          </Symbol>
+          <ByteSize>80281600</ByteSize>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.bSTOEnable1</Name>
             <Comment> STO Button</Comment>
@@ -35044,7 +37931,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635701888</BitOffs>
+            <BitOffs>634679040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.bSTOEnable2</Name>
@@ -35056,7 +37943,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635701896</BitOffs>
+            <BitOffs>634679048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.stYupEnc</Name>
@@ -35069,7 +37956,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635701952</BitOffs>
+            <BitOffs>634679104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.stYdwnEnc</Name>
@@ -35081,7 +37968,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635702080</BitOffs>
+            <BitOffs>634679232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.stXupEnc</Name>
@@ -35093,7 +37980,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635702208</BitOffs>
+            <BitOffs>634679360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.stXdwnEnc</Name>
@@ -35105,7 +37992,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635702336</BitOffs>
+            <BitOffs>634679488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -35118,7 +38005,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635703104</BitOffs>
+            <BitOffs>634680256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -35131,7 +38018,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635703232</BitOffs>
+            <BitOffs>634680384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -35144,7 +38031,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635713856</BitOffs>
+            <BitOffs>634691008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -35157,19 +38044,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635713984</BitOffs>
+            <BitOffs>634691136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635725312</BitOffs>
+            <BitOffs>634702464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -35192,7 +38079,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635733312</BitOffs>
+            <BitOffs>634710464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -35215,7 +38102,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635733320</BitOffs>
+            <BitOffs>634710472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -35238,7 +38125,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635733328</BitOffs>
+            <BitOffs>634710480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -35261,7 +38148,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635733344</BitOffs>
+            <BitOffs>634710496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -35274,7 +38161,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635733376</BitOffs>
+            <BitOffs>634710528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -35287,7 +38174,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635733440</BitOffs>
+            <BitOffs>634710592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -35300,19 +38187,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635733456</BitOffs>
+            <BitOffs>634710608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635750592</BitOffs>
+            <BitOffs>634727744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -35335,7 +38222,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635758592</BitOffs>
+            <BitOffs>634735744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -35358,7 +38245,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635758600</BitOffs>
+            <BitOffs>634735752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -35381,7 +38268,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635758608</BitOffs>
+            <BitOffs>634735760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -35404,7 +38291,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635758624</BitOffs>
+            <BitOffs>634735776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -35417,7 +38304,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635758656</BitOffs>
+            <BitOffs>634735808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -35430,7 +38317,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635758720</BitOffs>
+            <BitOffs>634735872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -35443,19 +38330,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635758736</BitOffs>
+            <BitOffs>634735888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635775872</BitOffs>
+            <BitOffs>634753024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -35478,7 +38365,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635783872</BitOffs>
+            <BitOffs>634761024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -35501,7 +38388,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635783880</BitOffs>
+            <BitOffs>634761032</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -35524,7 +38411,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635783888</BitOffs>
+            <BitOffs>634761040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -35547,7 +38434,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635783904</BitOffs>
+            <BitOffs>634761056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -35560,7 +38447,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635783936</BitOffs>
+            <BitOffs>634761088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -35573,7 +38460,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635784000</BitOffs>
+            <BitOffs>634761152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -35586,19 +38473,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635784016</BitOffs>
+            <BitOffs>634761168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635801152</BitOffs>
+            <BitOffs>634778304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -35621,7 +38508,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635809152</BitOffs>
+            <BitOffs>634786304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -35644,7 +38531,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635809160</BitOffs>
+            <BitOffs>634786312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -35667,7 +38554,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635809168</BitOffs>
+            <BitOffs>634786320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -35690,7 +38577,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635809184</BitOffs>
+            <BitOffs>634786336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -35703,7 +38590,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635809216</BitOffs>
+            <BitOffs>634786368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -35716,7 +38603,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635809280</BitOffs>
+            <BitOffs>634786432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -35729,19 +38616,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635809296</BitOffs>
+            <BitOffs>634786448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635826432</BitOffs>
+            <BitOffs>634803584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -35764,7 +38651,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635834432</BitOffs>
+            <BitOffs>634811584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -35787,7 +38674,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635834440</BitOffs>
+            <BitOffs>634811592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -35810,7 +38697,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635834448</BitOffs>
+            <BitOffs>634811600</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -35833,7 +38720,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635834464</BitOffs>
+            <BitOffs>634811616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -35846,7 +38733,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635834496</BitOffs>
+            <BitOffs>634811648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -35859,7 +38746,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635834560</BitOffs>
+            <BitOffs>634811712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -35872,19 +38759,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635834576</BitOffs>
+            <BitOffs>634811728</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635851712</BitOffs>
+            <BitOffs>634828864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -35907,7 +38794,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635859712</BitOffs>
+            <BitOffs>634836864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -35930,7 +38817,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635859720</BitOffs>
+            <BitOffs>634836872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -35953,7 +38840,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635859728</BitOffs>
+            <BitOffs>634836880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -35976,7 +38863,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635859744</BitOffs>
+            <BitOffs>634836896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -35989,7 +38876,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635859776</BitOffs>
+            <BitOffs>634836928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -36002,7 +38889,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635859840</BitOffs>
+            <BitOffs>634836992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -36015,67 +38902,67 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635859856</BitOffs>
+            <BitOffs>634837008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635878784</BitOffs>
+            <BitOffs>634855936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636205824</BitOffs>
+            <BitOffs>635184448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636532864</BitOffs>
+            <BitOffs>635512960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636859904</BitOffs>
+            <BitOffs>635841472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m6.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637186944</BitOffs>
+            <BitOffs>636169984</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
@@ -36088,14 +38975,14 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>637515008</BitOffs>
+            <BitOffs>636499520</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="OutputSrc" CreateSymbols="true">1</AreaNo>
           <Name>PlcTask Outputs</Name>
           <ContextId>0</ContextId>
-          <ByteSize>80347136</ByteSize>
+          <ByteSize>80281600</ByteSize>
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
@@ -36106,7 +38993,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635724288</BitOffs>
+            <BitOffs>634701440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -36129,7 +39016,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635733336</BitOffs>
+            <BitOffs>634710488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
@@ -36141,7 +39028,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635749568</BitOffs>
+            <BitOffs>634726720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -36164,7 +39051,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635758616</BitOffs>
+            <BitOffs>634735768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
@@ -36176,7 +39063,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635774848</BitOffs>
+            <BitOffs>634752000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -36199,7 +39086,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635783896</BitOffs>
+            <BitOffs>634761048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
@@ -36211,7 +39098,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635800128</BitOffs>
+            <BitOffs>634777280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -36234,7 +39121,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635809176</BitOffs>
+            <BitOffs>634786328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
@@ -36246,7 +39133,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635825408</BitOffs>
+            <BitOffs>634802560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -36269,7 +39156,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635834456</BitOffs>
+            <BitOffs>634811608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
@@ -36281,7 +39168,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635850688</BitOffs>
+            <BitOffs>634827840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -36304,7 +39191,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635859736</BitOffs>
+            <BitOffs>634836888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -36316,7 +39203,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635877760</BitOffs>
+            <BitOffs>634854912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -36328,7 +39215,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636204800</BitOffs>
+            <BitOffs>635183424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -36340,7 +39227,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636531840</BitOffs>
+            <BitOffs>635511936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -36352,7 +39239,7 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636858880</BitOffs>
+            <BitOffs>635840448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m6.fbDriveVirtual.MasterAxis.PlcToNc</Name>
@@ -36364,25 +39251,25 @@ External Setpoint Generation:
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>637185920</BitOffs>
+            <BitOffs>636168960</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="Internal" CreateSymbols="true">3</AreaNo>
           <Name>PlcTask Internal</Name>
           <ContextId>0</ContextId>
-          <ByteSize>80347136</ByteSize>
+          <ByteSize>80281600</ByteSize>
           <Symbol>
             <Name>DefaultGlobals.stSys</Name>
             <Comment>Included for you</Comment>
-            <BitSize>88</BitSize>
+            <BitSize>40</BitSize>
             <BaseType Namespace="LCLS_General">ST_System</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096000</BitOffs>
+            <BitOffs>3072000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.bTrickleTripped</Name>
@@ -36402,14 +39289,16 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096088</BitOffs>
+            <BitOffs>3072040</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GeneralConstants.MAX_STATES</Name>
-            <Comment> 16 including "Unknown" is the max for an EPICS MBBI
- This is the max number of user-defined states (OUT, TARGET1, YAG...)</Comment>
+            <Comment> 16 including "Unknown" is the max for an EPICS MBBI/MBBO
+ This is the max number of user-defined states (OUT, TARGET1, YAG...)
+ You can make this smaller if you want to use less memory in your program in exchange for limiting your max state count
+ You can make this larger if you want to use states-based FBs sized beyond the EPICS enum limit</Comment>
             <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
+            <BaseType>UINT</BaseType>
             <Default>
               <Value>15</Value>
             </Default>
@@ -36418,29 +39307,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.iLogPort</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>54321</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)LCLSGeneral:LogPort
-        io: io
-        field: DESC The log host UDP port
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096112</BitOffs>
+            <BitOffs>3072048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>DefaultGlobals.fTimeStamp</Name>
@@ -36451,7 +39318,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096128</BitOffs>
+            <BitOffs>3072064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.cLogHost</Name>
@@ -36482,7 +39349,29 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096192</BitOffs>
+            <BitOffs>3072128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Logger.iLogPort</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>54321</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)LCLSGeneral:LogPort
+        io: io
+        field: DESC The log host UDP port
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3072256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.sIpTidbit</Name>
@@ -36496,7 +39385,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096320</BitOffs>
+            <BitOffs>3072272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_LOADED</Name>
@@ -36511,22 +39400,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nLocalTripThreshold</Name>
-            <Comment> Minimum time between log messages</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4096384</BitOffs>
+            <BitOffs>3072328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.nMinTimeViolationAcceptable</Name>
@@ -36541,22 +39415,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096416</BitOffs>
+            <BitOffs>3072336</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Variables.AMSPORT_LOGGER</Name>
-            <Comment> Logger </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
+            <Name>GVL_Logger.nLocalTripThreshold</Name>
+            <Comment> Minimum time between log messages</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
             <Default>
-              <Value>100</Value>
+              <Value>1</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096432</BitOffs>
+            <BitOffs>3072352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.nLocalTrickleTripThreshold</Name>
@@ -36571,7 +39445,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096448</BitOffs>
+            <BitOffs>3072384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.nTrickleTripTime</Name>
@@ -36586,7 +39460,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096480</BitOffs>
+            <BitOffs>3072416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.nTripResetPeriod</Name>
@@ -36601,7 +39475,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096512</BitOffs>
+            <BitOffs>3072448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.sPlcHostname</Name>
@@ -36615,7 +39489,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4096544</BitOffs>
+            <BitOffs>3072480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_INVALID</Name>
@@ -36630,22 +39504,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097192</BitOffs>
+            <BitOffs>3073128</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Variables.AMSPORT_EVENTLOG</Name>
-            <Comment> Event logger </Comment>
+            <Name>Global_Variables.AMSPORT_LOGGER</Name>
+            <Comment> Logger </Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
             <Default>
-              <Value>110</Value>
+              <Value>100</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097200</BitOffs>
+            <BitOffs>3073136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.TCPADS_MAXUDP_BUFFSIZE</Name>
@@ -36660,10 +39534,14 @@ External Setpoint Generation:
             </Default>
             <Properties>
               <Property>
+                <Name>analysis</Name>
+                <Value>-33</Value>
+              </Property>
+              <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097216</BitOffs>
+            <BitOffs>3073152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.nGlobAccEvents</Name>
@@ -36683,34 +39561,19 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097248</BitOffs>
+            <BitOffs>3073184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Logger.fbRootLogger</Name>
             <Comment>Instantiated here to be used everywhere</Comment>
-            <BitSize>86016</BitSize>
+            <BitSize>86080</BitSize>
             <BaseType Namespace="LCLS_General">FB_LogMessage</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4097280</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Logger.nTrickleThreshold</Name>
-            <Comment> If GlobAccEvents goes over this level for longer than the</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4183296</BitOffs>
+            <BitOffs>3073216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_EtherCAT</Name>
@@ -36750,7 +39613,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183328</BitOffs>
+            <BitOffs>3159296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Standard</Name>
@@ -36790,7 +39653,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183616</BitOffs>
+            <BitOffs>3159584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_System</Name>
@@ -36830,7 +39693,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4183904</BitOffs>
+            <BitOffs>3159872</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.AMSPORT_EVENTLOG</Name>
+            <Comment> Event logger </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>110</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3160160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_RTIME</Name>
@@ -36845,7 +39723,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184192</BitOffs>
+            <BitOffs>3160176</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_IO</Name>
@@ -36860,7 +39738,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184208</BitOffs>
+            <BitOffs>3160192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NC</Name>
@@ -36874,7 +39752,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184224</BitOffs>
+            <BitOffs>3160208</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NCSAF</Name>
@@ -36888,7 +39766,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184240</BitOffs>
+            <BitOffs>3160224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_NCSVB</Name>
@@ -36902,7 +39780,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184256</BitOffs>
+            <BitOffs>3160240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_ISG</Name>
@@ -36916,7 +39794,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184272</BitOffs>
+            <BitOffs>3160256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CNC</Name>
@@ -36930,7 +39808,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184288</BitOffs>
+            <BitOffs>3160272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_LINE</Name>
@@ -36944,7 +39822,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184304</BitOffs>
+            <BitOffs>3160288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC</Name>
@@ -36958,7 +39836,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184320</BitOffs>
+            <BitOffs>3160304</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS1</Name>
@@ -36973,7 +39851,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184336</BitOffs>
+            <BitOffs>3160320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS2</Name>
@@ -36988,7 +39866,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184352</BitOffs>
+            <BitOffs>3160336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS3</Name>
@@ -37003,7 +39881,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184368</BitOffs>
+            <BitOffs>3160352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_PLC_RTS4</Name>
@@ -37018,7 +39896,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184384</BitOffs>
+            <BitOffs>3160368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CAM</Name>
@@ -37032,7 +39910,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184400</BitOffs>
+            <BitOffs>3160384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R0_CAMTOOL</Name>
@@ -37047,7 +39925,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184416</BitOffs>
+            <BitOffs>3160400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SYSSERV</Name>
@@ -37062,7 +39940,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184432</BitOffs>
+            <BitOffs>3160416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSPORT_R3_SCOPESERVER</Name>
@@ -37077,7 +39955,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184448</BitOffs>
+            <BitOffs>3160432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INVALID</Name>
@@ -37092,7 +39970,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184464</BitOffs>
+            <BitOffs>3160448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_IDLE</Name>
@@ -37106,7 +39984,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184480</BitOffs>
+            <BitOffs>3160464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RESET</Name>
@@ -37120,7 +39998,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184496</BitOffs>
+            <BitOffs>3160480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INIT</Name>
@@ -37134,7 +40012,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184512</BitOffs>
+            <BitOffs>3160496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_START</Name>
@@ -37148,7 +40026,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184528</BitOffs>
+            <BitOffs>3160512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RUN</Name>
@@ -37162,7 +40040,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184544</BitOffs>
+            <BitOffs>3160528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_STOP</Name>
@@ -37176,7 +40054,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184560</BitOffs>
+            <BitOffs>3160544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SAVECFG</Name>
@@ -37190,7 +40068,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184576</BitOffs>
+            <BitOffs>3160560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_LOADCFG</Name>
@@ -37204,7 +40082,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184592</BitOffs>
+            <BitOffs>3160576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_POWERFAILURE</Name>
@@ -37218,7 +40096,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184608</BitOffs>
+            <BitOffs>3160592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_POWERGOOD</Name>
@@ -37232,7 +40110,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184624</BitOffs>
+            <BitOffs>3160608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_ERROR</Name>
@@ -37246,7 +40124,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184640</BitOffs>
+            <BitOffs>3160624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SHUTDOWN</Name>
@@ -37260,7 +40138,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184656</BitOffs>
+            <BitOffs>3160640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_SUSPEND</Name>
@@ -37274,7 +40152,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184672</BitOffs>
+            <BitOffs>3160656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RESUME</Name>
@@ -37288,7 +40166,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184688</BitOffs>
+            <BitOffs>3160672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_CONFIG</Name>
@@ -37303,7 +40181,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184704</BitOffs>
+            <BitOffs>3160688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_RECONFIG</Name>
@@ -37318,7 +40196,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184720</BitOffs>
+            <BitOffs>3160704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_STOPPING</Name>
@@ -37332,7 +40210,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184736</BitOffs>
+            <BitOffs>3160720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_INCOMPATIBLE</Name>
@@ -37346,7 +40224,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184752</BitOffs>
+            <BitOffs>3160736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_EXCEPTION</Name>
@@ -37360,7 +40238,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184768</BitOffs>
+            <BitOffs>3160752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.ADSSTATE_MAXSTATES</Name>
@@ -37375,916 +40253,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4184784</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYMTAB</Name>
-            <Comment> Symbol table </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61440</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4184800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYMNAME</Name>
-            <Comment> Symbol name </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61441</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4184832</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYMVAL</Name>
-            <Comment> Symbol value </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61442</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4184864</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_HNDBYNAME</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61443</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4184896</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_VALBYNAME</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61444</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4184928</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_VALBYHND</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61445</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4184960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_RELEASEHND</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61446</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4184992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAME</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61447</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185024</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_VERSION</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61448</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185056</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAMEEX</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61449</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185088</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_DOWNLOAD</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61450</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185120</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_UPLOAD</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61451</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185152</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYM_UPLOADINFO</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61452</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_SYMNOTE</Name>
-            <Comment> Notification of named handle </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61456</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185216</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIB</Name>
-            <Comment> Read/write input BYTE(S) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61472</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185248</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIX</Name>
-            <Comment> Read/write input bit </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61473</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185280</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_RISIZE</Name>
-            <Comment> Read input size (in BYTE) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61477</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185312</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOB</Name>
-            <Comment> Read/write output BYTE(S) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61488</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185344</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOX</Name>
-            <Comment> Read/write output bit </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61489</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185376</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_ROSIZE</Name>
-            <Comment> Read/write output bit </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61493</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185408</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARI</Name>
-            <Comment> Write inputs TO null </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61504</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185440</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARO</Name>
-            <Comment> Write outputs TO null </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61520</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185472</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIOB</Name>
-            <Comment> Read input AND write output BYTE(S)  ADS-READWRITE </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61536</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185504</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIGRP_DEVICE_DATA</Name>
-            <Comment> State, name, etc... </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>61696</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185536</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIOFFS_DEVDATA_ADSSTATE</Name>
-            <Comment> Ads state OF device </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185568</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSIOFFS_DEVDATA_DEVSTATE</Name>
-            <Comment> Device state </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185600</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_OPENCREATE</Name>
-            <Comment> Open and if not existing create </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185632</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_OPENREAD</Name>
-            <Comment> Open existing for read access </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>101</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185664</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_OPENWRITE</Name>
-            <Comment> Open existing for write access </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>102</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185696</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_CREATEFILE</Name>
-            <Comment> Create </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>110</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185728</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_CLOSEHANDLE</Name>
-            <Comment> Close </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>111</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185760</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FOPEN</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>120</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185792</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FCLOSE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>121</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185824</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FREAD</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>122</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FWRITE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>123</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185888</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FSEEK</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>124</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185920</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FTELL</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>125</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185952</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FGETS</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>126</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4185984</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FPUTS</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>127</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186016</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FSCANF</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>128</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186048</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FPRINTF</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>129</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186080</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FEOF</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>130</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186112</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FDELETE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>131</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186144</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_FRENAME</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>132</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186176</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_MKDIR</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>138</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186208</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_RMDIR</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>139</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_REG_HKEYLOCALMACHINE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>200</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186272</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_SENDEMAIL</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>300</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186304</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_TIMESERVICES</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>400</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186336</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_STARTPROCESS</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>500</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186368</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMSERVICE_CHANGENETID</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>600</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186400</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.TIMESERVICE_DATEANDTIME</Name>
-            <Comment> Date/time </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186432</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.TIMESERVICE_SYSTEMTIMES</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186464</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.TIMESERVICE_RTCTIMEDIFF</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>3</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186496</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.TIMESERVICE_ADJUSTTIMETORTC</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186528</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.TIMESERVICE_TIMEZONINFORMATION</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>6</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186560</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_HINT</Name>
-            <Comment> Hint icon </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186592</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_WARN</Name>
-            <Comment> Warning icon </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186624</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_ERROR</Name>
-            <Comment> Error icon </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186656</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_LOG</Name>
-            <Comment> Write message to log file </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186688</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_MSGBOX</Name>
-            <Comment> View message in message box </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>32</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186720</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_RESOURCE</Name>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>64</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186752</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ADSLOG_MSGTYPE_STRING</Name>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>128</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186784</BitOffs>
+            <BitOffs>3160768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_RETAIN_REQUESTED</Name>
@@ -38298,7 +40267,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4186816</BitOffs>
+            <BitOffs>3160784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_LOADED</Name>
@@ -38313,7 +40282,916 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4186824</BitOffs>
+            <BitOffs>3160792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYMTAB</Name>
+            <Comment> Symbol table </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61440</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3160800</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYMNAME</Name>
+            <Comment> Symbol name </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61441</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3160832</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYMVAL</Name>
+            <Comment> Symbol value </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61442</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3160864</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_HNDBYNAME</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61443</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3160896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_VALBYNAME</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61444</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3160928</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_VALBYHND</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61445</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3160960</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_RELEASEHND</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61446</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3160992</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAME</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61447</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161024</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_VERSION</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61448</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161056</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_INFOBYNAMEEX</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61449</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_DOWNLOAD</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61450</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_UPLOAD</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61451</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYM_UPLOADINFO</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61452</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_SYMNOTE</Name>
+            <Comment> Notification of named handle </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61456</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIB</Name>
+            <Comment> Read/write input BYTE(S) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61472</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIX</Name>
+            <Comment> Read/write input bit </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61473</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161280</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_RISIZE</Name>
+            <Comment> Read input size (in BYTE) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61477</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161312</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOB</Name>
+            <Comment> Read/write output BYTE(S) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61488</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161344</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWOX</Name>
+            <Comment> Read/write output bit </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61489</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161376</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_ROSIZE</Name>
+            <Comment> Read/write output bit </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61493</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161408</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARI</Name>
+            <Comment> Write inputs TO null </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61504</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161440</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_CLEARO</Name>
+            <Comment> Write outputs TO null </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61520</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161472</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_IOIMAGE_RWIOB</Name>
+            <Comment> Read input AND write output BYTE(S)  ADS-READWRITE </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61536</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161504</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIGRP_DEVICE_DATA</Name>
+            <Comment> State, name, etc... </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>61696</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161536</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIOFFS_DEVDATA_ADSSTATE</Name>
+            <Comment> Ads state OF device </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161568</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSIOFFS_DEVDATA_DEVSTATE</Name>
+            <Comment> Device state </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161600</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_OPENCREATE</Name>
+            <Comment> Open and if not existing create </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>100</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161632</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_OPENREAD</Name>
+            <Comment> Open existing for read access </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>101</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161664</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_OPENWRITE</Name>
+            <Comment> Open existing for write access </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>102</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161696</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_CREATEFILE</Name>
+            <Comment> Create </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>110</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161728</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_CLOSEHANDLE</Name>
+            <Comment> Close </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>111</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161760</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FOPEN</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>120</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FCLOSE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>121</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161824</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FREAD</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>122</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161856</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FWRITE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>123</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161888</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FSEEK</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>124</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161920</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FTELL</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>125</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161952</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FGETS</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>126</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3161984</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FPUTS</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>127</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162016</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FSCANF</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>128</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162048</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FPRINTF</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>129</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162080</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FEOF</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>130</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FDELETE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>131</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162144</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_FRENAME</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>132</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162176</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_MKDIR</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>138</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162208</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_RMDIR</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>139</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162240</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_REG_HKEYLOCALMACHINE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>200</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162272</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_SENDEMAIL</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>300</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_TIMESERVICES</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>400</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162336</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_STARTPROCESS</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>500</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMSERVICE_CHANGENETID</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>600</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162400</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.TIMESERVICE_DATEANDTIME</Name>
+            <Comment> Date/time </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162432</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.TIMESERVICE_SYSTEMTIMES</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162464</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.TIMESERVICE_RTCTIMEDIFF</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>3</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162496</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.TIMESERVICE_ADJUSTTIMETORTC</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162528</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.TIMESERVICE_TIMEZONINFORMATION</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>6</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162560</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_HINT</Name>
+            <Comment> Hint icon </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162592</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_WARN</Name>
+            <Comment> Warning icon </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162624</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_ERROR</Name>
+            <Comment> Error icon </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162656</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_LOG</Name>
+            <Comment> Write message to log file </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_MSGBOX</Name>
+            <Comment> View message in message box </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>32</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162720</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_RESOURCE</Name>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>64</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162752</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ADSLOG_MSGTYPE_STRING</Name>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>128</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3162784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.BOOTDATAFLAGS_PERSISTENT_INVALID</Name>
@@ -38328,7 +41206,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4186832</BitOffs>
+            <BitOffs>3162816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSTATEFLAGS_BSOD</Name>
@@ -38343,7 +41221,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4186840</BitOffs>
+            <BitOffs>3162824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSTATEFLAGS_RTVIOLATION</Name>
@@ -38358,7 +41236,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4186848</BitOffs>
+            <BitOffs>3162832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.nWatchdogTime</Name>
@@ -38370,22 +41248,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4186856</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.TCEVENTFLAG_PRIOCLASS</Name>
-            <Comment> Event class/priority	through textformatter</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>WORD</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4186864</BitOffs>
+            <BitOffs>3162840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEREAD</Name>
@@ -38400,7 +41263,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4186880</BitOffs>
+            <BitOffs>3162848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEWRITE</Name>
@@ -38415,7 +41278,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4186912</BitOffs>
+            <BitOffs>3162880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEAPPEND</Name>
@@ -38430,7 +41293,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4186944</BitOffs>
+            <BitOffs>3162912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEPLUS</Name>
@@ -38445,7 +41308,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4186976</BitOffs>
+            <BitOffs>3162944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODEBINARY</Name>
@@ -38460,7 +41323,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187008</BitOffs>
+            <BitOffs>3162976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FOPEN_MODETEXT</Name>
@@ -38475,7 +41338,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187040</BitOffs>
+            <BitOffs>3163008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.TCEVENTFLAG_PRIOCLASS</Name>
+            <Comment> Event class/priority	through textformatter</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>WORD</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3163264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_FMTSELF</Name>
@@ -38490,7 +41368,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187296</BitOffs>
+            <BitOffs>3163280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_LOG</Name>
@@ -38505,7 +41383,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187312</BitOffs>
+            <BitOffs>3163296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_MSGBOX</Name>
@@ -38520,7 +41398,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187328</BitOffs>
+            <BitOffs>3163312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_SRCID</Name>
@@ -38535,7 +41413,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187344</BitOffs>
+            <BitOffs>3163328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTFLAG_AUTOFMTALL</Name>
@@ -38549,7 +41427,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187360</BitOffs>
+            <BitOffs>3163344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_INVALID</Name>
@@ -38564,7 +41442,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187376</BitOffs>
+            <BitOffs>3163360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_SIGNALED</Name>
@@ -38579,7 +41457,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187392</BitOffs>
+            <BitOffs>3163376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_RESET</Name>
@@ -38594,7 +41472,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187408</BitOffs>
+            <BitOffs>3163392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_CONFIRMED</Name>
@@ -38609,7 +41487,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187424</BitOffs>
+            <BitOffs>3163408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENTSTATE_RESETCON</Name>
@@ -38624,7 +41502,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187440</BitOffs>
+            <BitOffs>3163424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENT_SRCNAMESIZE</Name>
@@ -38638,7 +41516,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187456</BitOffs>
+            <BitOffs>3163440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TCEVENT_FMTPRGSIZE</Name>
@@ -38652,7 +41530,21 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187472</BitOffs>
+            <BitOffs>3163456</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.eWatchdogConfig</Name>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="Tc2_System">E_WATCHDOG_TIME_CONFIG</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3163472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_ADS_TIMEOUT</Name>
@@ -38667,7 +41559,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187488</BitOffs>
+            <BitOffs>3163488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.PI</Name>
@@ -38681,7 +41573,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187520</BitOffs>
+            <BitOffs>3163520</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_STRING_LENGTH</Name>
@@ -38696,44 +41588,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4187584</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.eWatchdogConfig</Name>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="Tc2_System">E_WATCHDOG_TIME_CONFIG</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4188128</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.MAX_AVERAGE_MEASURES</Name>
-            <Comment> Max. number of measures used in the profiler function block: 2..100 </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>10</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>LowerBorder</Name>
-                <Value>2</Value>
-              </Property>
-              <Property>
-                <Name>UpperBorder</Name>
-                <Value>100</Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4188144</BitOffs>
+            <BitOffs>3163584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_Module</Name>
@@ -38769,7 +41624,37 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4188160</BitOffs>
+            <BitOffs>3164128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.MAX_AVERAGE_MEASURES</Name>
+            <Comment> Max. number of measures used in the profiler function block: 2..100 </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT (2..100)</BaseType>
+            <Default>
+              <Value>10</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3164704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.GLOBAL_FORMAT_HASH_PREFIX_TYPE</Name>
+            <Comment> Global hash prefix type constant used for binary, octal or hexadecimal string format type </Comment>
+            <BitSize>16</BitSize>
+            <BaseType Namespace="Tc2_Utilities">E_HashPrefixTypes</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3164720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Utilities</Name>
@@ -38809,22 +41694,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4188800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.GLOBAL_FORMAT_HASH_PREFIX_TYPE</Name>
-            <Comment> Global hash prefix type constant used for binary, octal or hexadecimal string format type </Comment>
-            <BitSize>16</BitSize>
-            <BaseType Namespace="Tc2_Utilities">E_HashPrefixTypes</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4189088</BitOffs>
+            <BitOffs>3164800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_SBCS_TABLE</Name>
@@ -38839,22 +41709,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4189104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.GLOBAL_DCF77_PULSE_SPLIT</Name>
-            <Comment> Default DCF77 short/long pulse split time value. Bit == 0 =&gt; pulse &lt; 140ms, Bit == 1 =&gt; pulse &gt;= 140ms </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>TIME</BaseType>
-            <Default>
-              <Value>140</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4189120</BitOffs>
+            <BitOffs>3165088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.GLOBAL_DCF77_SEQUENCE_CHECK</Name>
@@ -38869,7 +41724,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4189152</BitOffs>
+            <BitOffs>3165104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_FIELD_SEP</Name>
@@ -38884,22 +41739,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4189160</BitOffs>
+            <BitOffs>3165112</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Variables.MAX_REMOTE_PCS</Name>
-            <Comment> Max. number of TwinCAT remote systems/PC's </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
+            <Name>Global_Variables.GLOBAL_DCF77_PULSE_SPLIT</Name>
+            <Comment> Default DCF77 short/long pulse split time value. Bit == 0 =&gt; pulse &lt; 140ms, Bit == 1 =&gt; pulse &gt;= 140ms </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>TIME</BaseType>
             <Default>
-              <Value>99</Value>
+              <Value>140</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4189168</BitOffs>
+            <BitOffs>3165120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ADAPTER_NAME_LENGTH</Name>
@@ -38914,7 +41769,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4250656</BitOffs>
+            <BitOffs>3226624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ADAPTER_DESCRIPTION_LENGTH</Name>
@@ -38929,7 +41784,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4250688</BitOffs>
+            <BitOffs>3226656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ADAPTER_ADDRESS_LENGTH</Name>
@@ -38944,7 +41799,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4250720</BitOffs>
+            <BitOffs>3226688</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_IPHELPERAPI</Name>
@@ -38959,7 +41814,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4250752</BitOffs>
+            <BitOffs>3226720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_IPHOSTNAME</Name>
@@ -38974,7 +41829,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4250784</BitOffs>
+            <BitOffs>3226752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.IPHELPERAPI_ADAPTERSINFO</Name>
@@ -38989,7 +41844,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4250816</BitOffs>
+            <BitOffs>3226784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.IPHELPERAPI_IPADDRBYHOSTNAME</Name>
@@ -39004,7 +41859,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4250848</BitOffs>
+            <BitOffs>3226816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_LOCAL_ADAPTERS</Name>
@@ -39019,7 +41874,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4250880</BitOffs>
+            <BitOffs>3226848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_ADDREMOTE</Name>
@@ -39034,7 +41889,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4250912</BitOffs>
+            <BitOffs>3226880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_DELREMOTE</Name>
@@ -39049,7 +41904,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4250944</BitOffs>
+            <BitOffs>3226912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_ENUMREMOTE</Name>
@@ -39064,52 +41919,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4250976</BitOffs>
+            <BitOffs>3226944</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Variables.ROUTE_FLAG_TEMPORARY</Name>
-            <Comment> TwinCAT route flag: Temporary </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
+            <Name>Global_Variables.MAX_REMOTE_PCS</Name>
+            <Comment> Max. number of TwinCAT remote systems/PC's </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
             <Default>
-              <Value>1</Value>
+              <Value>99</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4251008</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ROUTE_FLAG_DYNAMIC</Name>
-            <Comment> TwinCAT route flag: Hostname instead OF IP address </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>2</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4251040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.ROUTE_FLAG_NOOVERRIDE</Name>
-            <Comment> TwinCAT route flag: No override </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>4</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4251072</BitOffs>
+            <BitOffs>3226976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_NAME_LEN</Name>
@@ -39124,7 +41949,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4251104</BitOffs>
+            <BitOffs>3226992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_ADDR_LEN</Name>
@@ -39139,7 +41964,52 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4251112</BitOffs>
+            <BitOffs>3227000</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ROUTE_FLAG_TEMPORARY</Name>
+            <Comment> TwinCAT route flag: Temporary </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3227008</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ROUTE_FLAG_DYNAMIC</Name>
+            <Comment> TwinCAT route flag: Hostname instead OF IP address </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>2</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3227040</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.ROUTE_FLAG_NOOVERRIDE</Name>
+            <Comment> TwinCAT route flag: No override </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>4</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3227072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MIN_ROUTE_TRANSPORT</Name>
@@ -39154,7 +42024,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4251120</BitOffs>
+            <BitOffs>3227104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.MAX_ROUTE_TRANSPORT</Name>
@@ -39169,7 +42039,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4251128</BitOffs>
+            <BitOffs>3227112</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.AMSPORT_AMSLOGGER</Name>
+            <Comment> TwinCAT Ams Logger port number </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>10502</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3227120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_ROUTE_ENTRY</Name>
@@ -39203,7 +42088,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4251136</BitOffs>
+            <BitOffs>3227136</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMSERVICE_FFILEFIND</Name>
@@ -39218,7 +42103,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252320</BitOffs>
+            <BitOffs>3228320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.HKEY_MAX_BINARY_DATA_SIZE</Name>
@@ -39233,7 +42118,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252352</BitOffs>
+            <BitOffs>3228352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSLOGGER_IGR_GENERAL</Name>
@@ -39248,7 +42133,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252384</BitOffs>
+            <BitOffs>3228384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.AMSLOGGER_IOF_MODE</Name>
@@ -39263,22 +42148,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252416</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.AMSPORT_AMSLOGGER</Name>
-            <Comment> TwinCAT Ams Logger port number </Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>10502</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4252448</BitOffs>
+            <BitOffs>3228416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_MAX_ARGS</Name>
@@ -39293,7 +42163,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252464</BitOffs>
+            <BitOffs>3228448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_EXP_IS_NAN</Name>
@@ -39308,7 +42178,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252480</BitOffs>
+            <BitOffs>3228464</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_EXP_IS_INF</Name>
@@ -39323,7 +42193,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252496</BitOffs>
+            <BitOffs>3228480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MAX_DIGITS</Name>
@@ -39338,7 +42208,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252512</BitOffs>
+            <BitOffs>3228496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MAX_PRECISION</Name>
@@ -39353,7 +42223,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252528</BitOffs>
+            <BitOffs>3228512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FLOATREC_MIN_PRECISION</Name>
@@ -39368,7 +42238,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252544</BitOffs>
+            <BitOffs>3228528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_NOERROR</Name>
@@ -39383,7 +42253,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252576</BitOffs>
+            <BitOffs>3228544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PERCENTSIGNPOSITION</Name>
@@ -39398,7 +42268,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252608</BitOffs>
+            <BitOffs>3228576</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_ASTERISKPOSITION</Name>
@@ -39413,7 +42283,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252640</BitOffs>
+            <BitOffs>3228608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_WIDTHVALUE</Name>
@@ -39428,7 +42298,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252672</BitOffs>
+            <BitOffs>3228640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PRECISIONVALUE</Name>
@@ -39443,7 +42313,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252704</BitOffs>
+            <BitOffs>3228672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_FLAGPOSITION</Name>
@@ -39458,7 +42328,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252736</BitOffs>
+            <BitOffs>3228704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_WIDTHPRECISIONVALPOS</Name>
@@ -39473,7 +42343,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252768</BitOffs>
+            <BitOffs>3228736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_PRECISIONDOTPOSITION</Name>
@@ -39488,7 +42358,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252800</BitOffs>
+            <BitOffs>3228768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_TYPEFIELDVALUE</Name>
@@ -39503,7 +42373,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252832</BitOffs>
+            <BitOffs>3228800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_ARGTYPEINVALID</Name>
@@ -39518,7 +42388,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252864</BitOffs>
+            <BitOffs>3228832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_UNACCEPTEDPARAMETER</Name>
@@ -39533,7 +42403,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252896</BitOffs>
+            <BitOffs>3228864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_INSUFFICIENTARGS</Name>
@@ -39548,7 +42418,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252928</BitOffs>
+            <BitOffs>3228896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_DESTBUFFOVERFLOW</Name>
@@ -39563,7 +42433,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252960</BitOffs>
+            <BitOffs>3228928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FMTERR_INVALIDPOINTERINPUT</Name>
@@ -39578,22 +42448,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4252992</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Variables.SYSTEMTIME_DATEDELTA_OFFSET</Name>
-            <Comment> Number of past days since year zero until 1 January 1601 </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>DWORD</BaseType>
-            <Default>
-              <Value>584389</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4253024</BitOffs>
+            <BitOffs>3228960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_ARG_VALUE</Name>
@@ -39619,7 +42474,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4253056</BitOffs>
+            <BitOffs>3228992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_HEXASC_CODES</Name>
@@ -39768,7 +42623,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4253184</BitOffs>
+            <BitOffs>3229120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.FORMAT_DECASC_CODES</Name>
@@ -39826,7 +42681,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4253440</BitOffs>
+            <BitOffs>3229376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_MAX_MONTHDAYS</Name>
@@ -39943,7 +42798,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4258928</BitOffs>
+            <BitOffs>3234864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_MAX_YEARSDAY</Name>
@@ -40076,7 +42931,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4259312</BitOffs>
+            <BitOffs>3235248</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Global_Variables.SYSTEMTIME_DATEDELTA_OFFSET</Name>
+            <Comment> Number of past days since year zero until 1 January 1601 </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>DWORD</BaseType>
+            <Default>
+              <Value>584389</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3235712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERMSEC</Name>
@@ -40098,7 +42968,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4259776</BitOffs>
+            <BitOffs>3235744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERSEC</Name>
@@ -40120,7 +42990,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4259840</BitOffs>
+            <BitOffs>3235808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERDAY</Name>
@@ -40142,7 +43012,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4259904</BitOffs>
+            <BitOffs>3235872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MIN</Name>
@@ -40164,7 +43034,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4259968</BitOffs>
+            <BitOffs>3235936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MAX</Name>
@@ -40186,7 +43056,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4260032</BitOffs>
+            <BitOffs>3236000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERMSEC64</Name>
@@ -40201,7 +43071,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4260096</BitOffs>
+            <BitOffs>3236096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERSEC64</Name>
@@ -40216,7 +43086,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4260160</BitOffs>
+            <BitOffs>3236160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_TICKSPERDAY64</Name>
@@ -40231,7 +43101,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4260224</BitOffs>
+            <BitOffs>3236224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MIN64</Name>
@@ -40246,7 +43116,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4260288</BitOffs>
+            <BitOffs>3236288</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.SYSTEMTIME_DATE_AND_TIME_MAX64</Name>
@@ -40261,7 +43131,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4260352</BitOffs>
+            <BitOffs>3236352</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.WEST_EUROPE_TZI</Name>
@@ -40334,7 +43204,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4260416</BitOffs>
+            <BitOffs>3236416</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DATE_AND_TIME_SECPERDAY</Name>
@@ -40349,7 +43219,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4265376</BitOffs>
+            <BitOffs>3241376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DATE_AND_TIME_SECPERWEEK</Name>
@@ -40364,7 +43234,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4265408</BitOffs>
+            <BitOffs>3241408</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_NONE</Name>
@@ -40379,7 +43249,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4271616</BitOffs>
+            <BitOffs>3247616</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_LOG</Name>
@@ -40394,7 +43264,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4271648</BitOffs>
+            <BitOffs>3247648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_FILE</Name>
@@ -40409,7 +43279,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4271680</BitOffs>
+            <BitOffs>3247680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DBG_OUTPUT_VISU</Name>
@@ -40424,7 +43294,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4271712</BitOffs>
+            <BitOffs>3247712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_FIELD_DOUBLE_QUOTE</Name>
@@ -40439,7 +43309,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390480</BitOffs>
+            <BitOffs>3367472</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_RECORD_SEP_CR</Name>
@@ -40454,7 +43324,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4390488</BitOffs>
+            <BitOffs>3367480</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_CSV_RECORD_SEP_LF</Name>
@@ -40469,7 +43339,34 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4391440</BitOffs>
+            <BitOffs>3367488</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
+            <Comment> TcUnit logs complete test results. These include:
+         - Number of test suites
+         - Number of tests
+         - Number of successful tests
+         - Number of failed tests
+         - Any eventual failed assertion (with the expected &amp; actual value plus an user defined message)
+       These are all printed to the ADS logger (Visual Studio error list) marked with ERROR criticality
+
+       On top of this TcUnit also reports some statistics/extended information with HINT/INFO criticality.
+       These statistics are more detailed results of the tests. This information is used when results are
+       being collected by an external software (such as TcUnit-Runner) to do for example Jenkins integration.
+       This extra information however takes time to print, so by setting the following parameter to FALSE
+       it will speed up TcUnit finishing. </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3369240</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_STRUCT</Name>
@@ -40526,7 +43423,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4393184</BitOffs>
+            <BitOffs>3369248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_STRING</Name>
@@ -40540,7 +43437,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4393312</BitOffs>
+            <BitOffs>3369376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.EMPTY_GUID_REGSTRING</Name>
@@ -40554,34 +43451,21 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4393608</BitOffs>
+            <BitOffs>3369672</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Param_TcUnit.LogExtendedResults</Name>
-            <Comment> TcUnit logs complete test results. These include:
-         - Number of test suites
-         - Number of tests
-         - Number of successful tests
-         - Number of failed tests
-         - Any eventual failed assertion (with the expected &amp; actual value plus an user defined message)
-       These are all printed to the ADS logger (Visual Studio error list) marked with ERROR criticality
-
-       On top of this TcUnit also reports some statistics/extended information with HINT/INFO criticality.
-       These statistics are more detailed results of the tests. This information is used when results are
-       being collected by an external software (such as TcUnit-Runner) to do for example Jenkins integration.
-       This extra information however takes time to print, so by setting the following parameter to FALSE
-       it will speed up TcUnit finishing. </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
+            <Name>Global_Constants.EMPTY_SEVERITY</Name>
+            <BitSize>16</BitSize>
+            <BaseType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</BaseType>
             <Default>
-              <Value>1</Value>
+              <Value>0</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4393928</BitOffs>
+            <BitOffs>3370064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_IoFunctions</Name>
@@ -40621,7 +43505,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4394016</BitOffs>
+            <BitOffs>3370080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_ModbusSrv</Name>
@@ -40657,7 +43541,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4394304</BitOffs>
+            <BitOffs>3370368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_SerialCom</Name>
@@ -40697,7 +43581,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4394592</BitOffs>
+            <BitOffs>3370656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_EVENT_CLASS</Name>
@@ -40754,7 +43638,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4394880</BitOffs>
+            <BitOffs>3370944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.EMPTY_EVENT_ID</Name>
@@ -40768,35 +43652,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4395008</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Global_Constants.EMPTY_SEVERITY</Name>
-            <BitSize>16</BitSize>
-            <BaseType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4395040</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>1000</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4395056</BitOffs>
+            <BitOffs>3371072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Constants.SUCCESS_EVENT</Name>
@@ -40861,7 +43717,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4395072</BitOffs>
+            <BitOffs>3371104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL.nLangId_OnlineMonitoring</Name>
@@ -40876,30 +43732,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4395264</BitOffs>
+            <BitOffs>3371296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>ParameterList.cSourceNameSize</Name>
             <Comment> size [bytes] for source names (recommended is a size between 128 and 512)</Comment>
             <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
+            <BaseType>UDINT (81..10000)</BaseType>
             <Default>
               <Value>256</Value>
             </Default>
             <Properties>
               <Property>
-                <Name>LowerBorder</Name>
-                <Value>81</Value>
-              </Property>
-              <Property>
-                <Name>UpperBorder</Name>
-                <Value>10000</Value>
-              </Property>
-              <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4395296</BitOffs>
+            <BitOffs>3371328</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_EventLogger</Name>
@@ -40939,7 +43787,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4395328</BitOffs>
+            <BitOffs>3371360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_INTERNAL.UNINITIALIZED_CLASS_GUID</Name>
@@ -40997,7 +43845,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4395616</BitOffs>
+            <BitOffs>3371648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>.TCPADS_MAXUDP_BUFFSIZE</Name>
@@ -41011,7 +43859,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4395744</BitOffs>
+            <BitOffs>3371776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc3_JsonXml</Name>
@@ -41051,7 +43899,21 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4395776</BitOffs>
+            <BitOffs>3371808</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.MaxNumberOfTestSuites</Name>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>1000</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3372096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite</Name>
@@ -41065,7 +43927,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4396064</BitOffs>
+            <BitOffs>3372112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.MaxNumberOfAssertsForEachTestSuite</Name>
@@ -41079,7 +43941,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4396080</BitOffs>
+            <BitOffs>3372128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.xUnitEnablePublish</Name>
@@ -41094,7 +43956,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4396096</BitOffs>
+            <BitOffs>3372144</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteIsRegistered</Name>
@@ -41106,7 +43968,37 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4396104</BitOffs>
+            <BitOffs>3372152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
+            <Comment> Default reserved PLC memory buffer used for composition of the xUnit xml file (64 kb default) </Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>65535</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3372160</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
+            <Comment> Default path and filename for the xunit testresults e.g.: for use with jenkins </Comment>
+            <BitSize>2048</BitSize>
+            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
+            <Default>
+              <String>C:\tcunit_xunit_testresults.xml</String>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3372192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.AdsLogMessageFifoRingBufferSize</Name>
@@ -41124,37 +44016,33 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4396112</BitOffs>
+            <BitOffs>3374240</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Param_TcUnit.xUnitBufferSize</Name>
-            <Comment> Default reserved PLC memory buffer used for composition of the xUnit xml file (64 kb default) </Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>65535</Value>
-            </Default>
+            <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
+            <Comment> Whether or not the current test being called has finished running </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4396128</BitOffs>
+            <BitOffs>3374256</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Param_TcUnit.xUnitFilePath</Name>
-            <Comment> Default path and filename for the xunit testresults e.g.: for use with jenkins </Comment>
-            <BitSize>2048</BitSize>
-            <BaseType Namespace="Tc2_System">T_MaxString</BaseType>
-            <Default>
-              <String>C:\tcunit_xunit_testresults.xml</String>
-            </Default>
+            <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
+            <Comment> This is a flag that indicates that the current test should be ignored, and
+       thus that all assertions under it should be ignored as well. A test can be ignored either
+       because the user has requested so, or because the test is a duplicate name </Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4396160</BitOffs>
+            <BitOffs>3374264</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Param_TcUnit.TimeBetweenTestSuitesExecution</Name>
@@ -41170,33 +44058,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4398208</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.CurrentTestIsFinished</Name>
-            <Comment> Whether or not the current test being called has finished running </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4398240</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>GVL_TcUnit.IgnoreCurrentTest</Name>
-            <Comment> This is a flag that indicates that the current test should be ignored, and
-       thus that all assertions under it should be ignored as well. A test can be ignored either
-       because the user has requested so, or because the test is a duplicate name </Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>4398248</BitOffs>
+            <BitOffs>3374272</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.NumberOfInitializedTestSuites</Name>
@@ -41212,18 +44074,33 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4398256</BitOffs>
+            <BitOffs>3374304</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
+            <Comment> Maximum # of attenuators in the PMPS</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>3374320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TcUnitRunner</Name>
-            <BitSize>621828352</BitSize>
+            <BitSize>621828480</BitSize>
             <BaseType Namespace="TcUnit">FB_TcUnitRunner</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>4398272</BitOffs>
+            <BitOffs>3374336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestSuiteBeingCalled</Name>
@@ -41235,7 +44112,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>626226624</BitOffs>
+            <BitOffs>625202816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentTestNameBeingCalled</Name>
@@ -41247,7 +44124,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>626226688</BitOffs>
+            <BitOffs>625202880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.TestSuiteAddresses</Name>
@@ -41262,7 +44139,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>626228736</BitOffs>
+            <BitOffs>625204928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.CurrentlyRunningOrderedTestInTestSuite</Name>
@@ -41270,25 +44147,17 @@ External Setpoint Generation:
        We do this by defining an array, in where we can see which current TEST_ORDERED() is the one to be handled right now.
        The below array is only used for TEST_ORDERED()-tests.  </Comment>
             <BitSize>16000</BitSize>
-            <BaseType>UINT</BaseType>
+            <BaseType>UINT (UINT#1..GVL_Param_TcUnit.MaxNumberOfTestsForEachTestSuite)</BaseType>
             <ArrayInfo>
               <LBound>1</LBound>
               <Elements>1000</Elements>
             </ArrayInfo>
             <Properties>
               <Property>
-                <Name>LowerBorder</Name>
-                <Value>1</Value>
-              </Property>
-              <Property>
-                <Name>UpperBorder</Name>
-                <Value>100</Value>
-              </Property>
-              <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>626292736</BitOffs>
+            <BitOffs>625268928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TcUnit.AdsMessageQueue</Name>
@@ -41300,7 +44169,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>626308736</BitOffs>
+            <BitOffs>625284928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_TcUnit</Name>
@@ -41336,37 +44205,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634629888</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
-            <Comment>An assertion ID that should always return "not found" in the assertion pool</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>4294967295</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634630176</BitOffs>
+            <BitOffs>633606080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.fbPmpsFileReader</Name>
-            <BitSize>935360</BitSize>
+            <BitSize>935616</BitSize>
             <BaseType Namespace="PMPS">FB_JsonFileToJsonDoc</BaseType>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634630208</BitOffs>
+            <BitOffs>633606400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.fbStandardPMPSDB</Name>
-            <BitSize>29760</BitSize>
+            <BitSize>30144</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</BaseType>
             <Properties>
               <Property>
@@ -41380,7 +44234,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635565568</BitOffs>
+            <BitOffs>634542016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stRequestedBeamParameters</Name>
@@ -41400,7 +44254,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635595328</BitOffs>
+            <BitOffs>634572160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.stCurrentBeamParameters</Name>
@@ -41420,7 +44274,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635597088</BitOffs>
+            <BitOffs>634573920</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundaries</Name>
@@ -41445,7 +44299,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635598848</BitOffs>
+            <BitOffs>634575680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.PERange</Name>
@@ -41457,7 +44311,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635599872</BitOffs>
+            <BitOffs>634576704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.EXCLUDED_ASSERTION_ID</Name>
+            <Comment>An assertion ID that should always return "not found" in the assertion pool</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>4294967295</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634576800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
@@ -41471,7 +44340,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635599936</BitOffs>
+            <BitOffs>634576896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
@@ -41485,7 +44354,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635600000</BitOffs>
+            <BitOffs>634576960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
@@ -41499,7 +44368,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635600064</BitOffs>
+            <BitOffs>634577024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.TRANS_SCALING_FACTOR</Name>
@@ -41514,22 +44383,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635600096</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
-            <Comment> Maximum # of attenuators in the PMPS</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635600128</BitOffs>
+            <BitOffs>634577056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
@@ -41543,68 +44397,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635600144</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.stAttenuators</Name>
-            <BitSize>64</BitSize>
-            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nTran</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.xAttOK</Name>
-                <Value>1</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635600160</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cstFullBeam</Name>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)FullBeamCnst
-		io: i
-        archive: 1Hz monitor
-        field: DESC Full beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635600224</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cst0RateBeam</Name>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)0RateBeamCnst
-		io: i
-        archive: 1Hz monitor
-        field: DESC 0-rate beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635601984</BitOffs>
+            <BitOffs>634577088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
@@ -41629,7 +44422,68 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635603744</BitOffs>
+            <BitOffs>634577104</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.stAttenuators</Name>
+            <BitSize>64</BitSize>
+            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nTran</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.xAttOK</Name>
+                <Value>1</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634577120</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cstFullBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)FullBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Full beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634577184</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cst0RateBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)0RateBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC 0-rate beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634578944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_APERTURES</Name>
@@ -41644,7 +44498,21 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635603760</BitOffs>
+            <BitOffs>634580704</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_cBoundaries</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>31</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634580720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
@@ -41663,36 +44531,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635603776</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.g_cBoundaries</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>31</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635604800</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
-            <Comment> Max fast faults for an FFO</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>50</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>635604816</BitOffs>
+            <BitOffs>634580736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.reVHyst</Name>
@@ -41719,7 +44558,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635604832</BitOffs>
+            <BitOffs>634581760</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesL</Name>
@@ -41874,7 +44713,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635604864</BitOffs>
+            <BitOffs>634581792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesK</Name>
@@ -42029,7 +44868,37 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635605888</BitOffs>
+            <BitOffs>634582816</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
+            <Comment> Max fast faults for an FFO</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>50</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634583840</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bLittleEndian</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>1</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634583864</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
@@ -42044,7 +44913,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635606912</BitOffs>
+            <BitOffs>634583872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.TRANS_MARGIN</Name>
@@ -42059,7 +44928,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635606944</BitOffs>
+            <BitOffs>634583904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_TOOLS.fbJson</Name>
@@ -42070,7 +44939,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635606976</BitOffs>
+            <BitOffs>634583936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -42110,7 +44979,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635607360</BitOffs>
+            <BitOffs>634584320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoRange</Name>
@@ -42125,7 +44994,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635607648</BitOffs>
+            <BitOffs>634584608</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -42136,7 +45005,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635607680</BitOffs>
+            <BitOffs>634584640</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -42150,7 +45019,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635614784</BitOffs>
+            <BitOffs>634591744</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -42164,7 +45033,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635614848</BitOffs>
+            <BitOffs>634591808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -42200,7 +45069,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635614912</BitOffs>
+            <BitOffs>634591872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_ControllerToolbox</Name>
@@ -42240,7 +45109,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>635615200</BitOffs>
+            <BitOffs>634592160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender</Name>
@@ -42257,7 +45126,7 @@ External Setpoint Generation:
  Test Bender vs No Bender</Comment>
             <BitSize>23552</BitSize>
             <BaseType>DUT_HOMS</BaseType>
-            <BitOffs>635700672</BitOffs>
+            <BitOffs>634677824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -42269,7 +45138,7 @@ External Setpoint Generation:
                 <Value>0</Value>
               </SubItem>
             </Default>
-            <BitOffs>635724224</BitOffs>
+            <BitOffs>634701376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -42281,7 +45150,7 @@ External Setpoint Generation:
                 <Value>0</Value>
               </SubItem>
             </Default>
-            <BitOffs>635749504</BitOffs>
+            <BitOffs>634726656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -42293,7 +45162,7 @@ External Setpoint Generation:
                 <Value>0</Value>
               </SubItem>
             </Default>
-            <BitOffs>635774784</BitOffs>
+            <BitOffs>634751936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -42305,7 +45174,7 @@ External Setpoint Generation:
                 <Value>0</Value>
               </SubItem>
             </Default>
-            <BitOffs>635800064</BitOffs>
+            <BitOffs>634777216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -42317,7 +45186,7 @@ External Setpoint Generation:
                 <Value>0</Value>
               </SubItem>
             </Default>
-            <BitOffs>635825344</BitOffs>
+            <BitOffs>634802496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -42329,43 +45198,43 @@ External Setpoint Generation:
                 <Value>0</Value>
               </SubItem>
             </Default>
-            <BitOffs>635850624</BitOffs>
+            <BitOffs>634827776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBender</Name>
             <BitSize>256</BitSize>
             <BaseType>FB_Bender</BaseType>
-            <BitOffs>635875904</BitOffs>
+            <BitOffs>634853056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1</Name>
-            <BitSize>327040</BitSize>
+            <BitSize>328512</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>635876160</BitOffs>
+            <BitOffs>634853312</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2</Name>
-            <BitSize>327040</BitSize>
+            <BitSize>328512</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>636203200</BitOffs>
+            <BitOffs>635181824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3</Name>
-            <BitSize>327040</BitSize>
+            <BitSize>328512</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>636530240</BitOffs>
+            <BitOffs>635510336</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4</Name>
-            <BitSize>327040</BitSize>
+            <BitSize>328512</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>636857280</BitOffs>
+            <BitOffs>635838848</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m6</Name>
-            <BitSize>327040</BitSize>
+            <BitSize>328512</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>637184320</BitOffs>
+            <BitOffs>636167360</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT</Name>
@@ -42380,7 +45249,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637512384</BitOffs>
+            <BitOffs>636496896</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMaxVoltage</Name>
@@ -42395,7 +45264,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637512448</BitOffs>
+            <BitOffs>636496960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMinVoltage</Name>
@@ -42410,7 +45279,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637512512</BitOffs>
+            <BitOffs>636497024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TestStructs.TestPitch_LimitSwitches</Name>
@@ -42439,7 +45308,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637512576</BitOffs>
+            <BitOffs>636497088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_lcls_twincat_optics</Name>
@@ -42475,26 +45344,11 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637515072</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support an FPU</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>637515368</BitOffs>
+            <BitOffs>636499584</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>64</BitSize>
             <BaseType>VERSION</BaseType>
             <Default>
@@ -42508,7 +45362,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.uiServicePack</Name>
-                <Value>6</Value>
+                <Value>13</Value>
               </SubItem>
               <SubItem>
                 <Name>.uiPatch</Name>
@@ -42520,11 +45374,11 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637515376</BitOffs>
+            <BitOffs>636499872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>64</BitSize>
             <BaseType>VERSION</BaseType>
             <Default>
@@ -42538,11 +45392,11 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.uiServicePack</Name>
-                <Value>10</Value>
+                <Value>13</Value>
               </SubItem>
               <SubItem>
                 <Name>.uiPatch</Name>
-                <Value>100</Value>
+                <Value>40</Value>
               </SubItem>
             </Default>
             <Properties>
@@ -42550,11 +45404,11 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637515440</BitOffs>
+            <BitOffs>636499936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Default>
@@ -42565,10 +45419,11 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637515504</BitOffs>
+            <BitOffs>636500000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.bFPUSupport</Name>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Default>
@@ -42579,11 +45434,11 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637515512</BitOffs>
+            <BitOffs>636500008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>16</BitSize>
             <BaseType>WORD</BaseType>
             <Default>
@@ -42594,11 +45449,11 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637515520</BitOffs>
+            <BitOffs>636500016</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
-            <Comment> Does the target support an FPU</Comment>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
             <Default>
@@ -42609,35 +45464,51 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637515536</BitOffs>
+            <BitOffs>636500032</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bMulticoreSupport</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Value>0</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636500048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>32</BitSize>
             <BaseType>DWORD</BaseType>
             <Default>
-              <Value>50660864</Value>
+              <Value>50662656</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637515552</BitOffs>
+            <BitOffs>636500064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
+            <Comment> Does the target support multiple cores?</Comment>
             <BitSize>32</BitSize>
             <BaseType>DWORD</BaseType>
             <Default>
-              <Value>50661988</Value>
+              <Value>50662696</Value>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637515584</BitOffs>
+            <BitOffs>636500096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -42706,7 +45577,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637515616</BitOffs>
+            <BitOffs>636500128</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -42720,12 +45591,12 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637516640</BitOffs>
+            <BitOffs>636501152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{5C8FF47F-7F83-4493-8D21-F1FF8A08F75A}">PlcAppSystemInfo</BaseType>
+            <BaseType GUID="{941FDF6E-37CE-4C30-AA23-3236AFA461E2}">PlcAppSystemInfo</BaseType>
             <Properties>
               <Property>
                 <Name>no_init</Name>
@@ -42734,7 +45605,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637516672</BitOffs>
+            <BitOffs>636501184</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -42752,7 +45623,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637518720</BitOffs>
+            <BitOffs>636503232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -42766,7 +45637,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637519744</BitOffs>
+            <BitOffs>636504256</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -42787,7 +45658,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637519808</BitOffs>
+            <BitOffs>636504320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
@@ -42803,6 +45674,9 @@ External Setpoint Generation:
                 <Name>const_non_replaced</Name>
               </Property>
               <Property>
+                <Name>init_on_onlchange</Name>
+              </Property>
+              <Property>
                 <Name>suppress_warning_0</Name>
                 <Value>C0228</Value>
               </Property>
@@ -42810,14 +45684,14 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>637567296</BitOffs>
+            <BitOffs>636555904</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
           <AreaNo AreaType="RetainSrc" CreateSymbols="true">4</AreaNo>
           <Name>PlcTask Retains</Name>
           <ContextId>0</ContextId>
-          <ByteSize>80347136</ByteSize>
+          <ByteSize>80281600</ByteSize>
           <Symbol>
             <Name>PMPS_GVL.SuccessfulPreemption</Name>
             <Comment> Any time BPTM applies a new BP request which is confirmed</Comment>
@@ -42835,7 +45709,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>3072000</BitOffs>
+            <BitOffs>633606368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.AccumulatedFF</Name>
@@ -42854,7 +45728,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>3072032</BitOffs>
+            <BitOffs>634576768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.BP_jsonDoc</Name>
@@ -42865,7 +45739,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>3072064</BitOffs>
+            <BitOffs>634576832</BitOffs>
           </Symbol>
         </DataArea>
       </DataAreas>
@@ -42882,15 +45756,15 @@ External Setpoint Generation:
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-04-06T14:14:27</Value>
+          <Value>2023-06-21T10:48:49</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>
-          <Value>573440</Value>
+          <Value>585728</Value>
         </Property>
         <Property>
           <Name>GlobalDataSize</Name>
-          <Value>79208448</Value>
+          <Value>79212544</Value>
         </Property>
       </Properties>
     </Module>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Changed offending `STRING` vars in `FB_PI_E621_SerialTransaction` and `FB_PI_E621_SerialDriver` to `T_MaxString`
- Installed as library version 0.6.1 
- Built with twincat version 4024.12.
- pre-commit run for the first time here.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tried to build `lcls-plc-xrt-optics` with 4024.12 and found `STRING` vars incompatible with `F_STRING` built in FB.

## How Has This Been Tested?
`lcls-plc-xrt-optics` running this version.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
