### PR TITLE
Separate Beam Parameters Not Loaded FFO

### DIFF
--- a/lcls-twincat-optics/_Config/PLC/lcls_twincat_optics_plc.xti
+++ b/lcls-twincat-optics/_Config/PLC/lcls_twincat_optics_plc.xti
@@ -1,16 +1,13 @@
 <?xml version="1.0"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12" ClassName="CNestedPlcProjDef">
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.35" ClassName="CNestedPlcProjDef">
 	<DataTypes>
 		<DataType>
-			<Name GUID="{4B0DBBA4-11EF-DC4A-BF0D-C44F27183D05}" Namespace="lcls_twincat_motion" AutoDeleteType="true">EL5042_Status</Name>
+			<Name GUID="{8F4975B4-B3D9-9C2F-B09A-E19B3FB61C15}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_EL5042_Status</Name>
 			<BitSize>0</BitSize>
 			<BaseType GUID="{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}"/>
-			<Hides>
-				<Hide GUID="{76D7CEE7-D4AA-4B15-95A1-1448CB4CAD61}"/>
-			</Hides>
 		</DataType>
 		<DataType>
-			<Name GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
+			<Name GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion" AutoDeleteType="true">ST_RenishawAbsEnc</Name>
 			<Comment><![CDATA[ Renishaw BiSS-C absolute encoder used with an EL5042]]></Comment>
 			<BitSize>128</BitSize>
 			<SubItem>
@@ -28,7 +25,7 @@
 			</SubItem>
 			<SubItem>
 				<Name>Status</Name>
-				<Type GUID="{4B0DBBA4-11EF-DC4A-BF0D-C44F27183D05}" Namespace="lcls_twincat_motion">EL5042_Status</Type>
+				<Type GUID="{8F4975B4-B3D9-9C2F-B09A-E19B3FB61C15}" Namespace="lcls_twincat_motion">ST_EL5042_Status</Type>
 				<Comment><![CDATA[ Status struct placeholder]]></Comment>
 				<BitSize>0</BitSize>
 				<BitOffs>64</BitOffs>
@@ -40,9 +37,6 @@
 				<BitSize>64</BitSize>
 				<BitOffs>64</BitOffs>
 			</SubItem>
-			<Hides>
-				<Hide GUID="{5869EE60-6725-4837-96DE-E65F28189E3C}"/>
-			</Hides>
 		</DataType>
 		<DataType>
 			<Name GUID="{CBC83B73-B816-4597-A9E5-2B03263CA131}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_STATE</Name>
@@ -255,7 +249,7 @@
 			</Relations>
 		</DataType>
 		<DataType>
-			<Name GUID="{6EF49753-C72C-4F50-AA44-3C7498E76CFE}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_OPMODE</Name>
+			<Name GUID="{6BDEED54-7268-405F-A18B-665A0AE0FEE9}" Namespace="MC" TcBaseType="true" HideType="true" IecDeclaration="DWORD;">NCTOPLC_AXIS_REF_OPMODE</Name>
 			<BitSize>32</BitSize>
 			<SubItem>
 				<Name>OpModePosAreaMonitoring</Name>
@@ -310,6 +304,18 @@
 				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
 				<BitSize>1</BitSize>
 				<BitOffs>8</BitOffs>
+			</SubItem>
+			<SubItem>
+				<Name>OpModeStopMonitoring</Name>
+				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+				<BitSize>1</BitSize>
+				<BitOffs>12</BitOffs>
+			</SubItem>
+			<SubItem>
+				<Name>OpModeOutputSmoothingFilter</Name>
+				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+				<BitSize>1</BitSize>
+				<BitOffs>13</BitOffs>
 			</SubItem>
 			<SubItem>
 				<Name>OpModePosLagMonitoring</Name>
@@ -405,6 +411,56 @@
 			</Format>
 		</DataType>
 		<DataType>
+			<Name GUID="{F7B9FC50-054E-4547-B468-83A9E72D8064}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE3_FLAGS</Name>
+			<BitSize>32</BitSize>
+			<SubItem>
+				<Name>TouchProbe1InputState </Name>
+				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+				<BitSize>1</BitSize>
+				<BitOffs>0</BitOffs>
+			</SubItem>
+			<SubItem>
+				<Name>TouchProbe2InputState </Name>
+				<Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+				<BitSize>1</BitSize>
+				<BitOffs>1</BitOffs>
+			</SubItem>
+			<Format Name="Short">
+				<Printf>%08x</Printf>
+			</Format>
+			<Format Name="Cpp">
+				<Printf>0x%08x</Printf>
+			</Format>
+			<Format Name="IEC">
+				<Printf>16#%08X</Printf>
+			</Format>
+		</DataType>
+		<DataType>
+			<Name GUID="{60E203BA-3CEE-4BB0-8728-643B1F529592}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE3</Name>
+			<BitSize>32</BitSize>
+			<SubItem>
+				<Name>Value</Name>
+				<Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
+				<BitSize>32</BitSize>
+				<BitOffs>0</BitOffs>
+			</SubItem>
+			<SubItem>
+				<Name>Flags</Name>
+				<Type GUID="{F7B9FC50-054E-4547-B468-83A9E72D8064}" Namespace="MC">NCTOPLC_AXIS_REF_STATE3_FLAGS</Type>
+				<BitSize>32</BitSize>
+				<BitOffs>0</BitOffs>
+			</SubItem>
+			<Format Name="Short">
+				<Printf>%08x</Printf>
+			</Format>
+			<Format Name="Cpp">
+				<Printf>0x%08x</Printf>
+			</Format>
+			<Format Name="IEC">
+				<Printf>16#%08X</Printf>
+			</Format>
+		</DataType>
+		<DataType>
 			<Name GUID="{BA9D9D0F-1A4A-4A27-A19F-3032626A8491}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_CAMCOUPLINGSTATE</Name>
 			<BitSize>8</BitSize>
 			<SubItem>
@@ -448,7 +504,7 @@
 			</ArrayInfo>
 		</DataType>
 		<DataType>
-			<Name GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+			<Name GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
 			<BitSize>2048</BitSize>
 			<SubItem>
 				<Name>StateDWord</Name>
@@ -536,7 +592,7 @@ External Setpoint Generation:
 			</SubItem>
 			<SubItem>
 				<Name>OpModeDWord</Name>
-				<Type GUID="{6EF49753-C72C-4F50-AA44-3C7498E76CFE}" Namespace="MC">NCTOPLC_AXIS_REF_OPMODE</Type>
+				<Type GUID="{6BDEED54-7268-405F-A18B-665A0AE0FEE9}" Namespace="MC">NCTOPLC_AXIS_REF_OPMODE</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>288</BitOffs>
 			</SubItem>
@@ -656,7 +712,7 @@ External Setpoint Generation:
 			</SubItem>
 			<SubItem>
 				<Name>StateDWord3</Name>
-				<Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
+				<Type GUID="{60E203BA-3CEE-4BB0-8728-643B1F529592}" Namespace="MC">NCTOPLC_AXIS_REF_STATE3</Type>
 				<BitSize>32</BitSize>
 				<BitOffs>1248</BitOffs>
 			</SubItem>
@@ -730,6 +786,12 @@ External Setpoint Generation:
 				<BitSize>32</BitSize>
 				<BitOffs>1920</BitOffs>
 			</SubItem>
+			<SubItem>
+				<Name>UserData</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+				<BitSize>64</BitSize>
+				<BitOffs>1984</BitOffs>
+			</SubItem>
 			<Properties>
 				<Property>
 					<Name>NcStructType</Name>
@@ -760,6 +822,12 @@ External Setpoint Generation:
 				</Relation>
 				<Relation Priority="100">
 					<Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}"></Type>
+				</Relation>
+				<Relation Priority="100">
+					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}"></Type>
+				</Relation>
+				<Relation Priority="100">
+					<Type GUID="{10036166-C9D3-404B-BDD3-323034AAA7F4}"></Type>
 				</Relation>
 			</Relations>
 		</DataType>
@@ -819,7 +887,7 @@ External Setpoint Generation:
 			</Format>
 		</DataType>
 		<DataType>
-			<Name GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF</Name>
+			<Name GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF</Name>
 			<BitSize>1024</BitSize>
 			<SubItem>
 				<Name>ControlDWord</Name>
@@ -929,6 +997,12 @@ External Setpoint Generation:
 				<BitSize>8</BitSize>
 				<BitOffs>848</BitOffs>
 			</SubItem>
+			<SubItem>
+				<Name>ExtTorque</Name>
+				<Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+				<BitSize>64</BitSize>
+				<BitOffs>896</BitOffs>
+			</SubItem>
 			<Properties>
 				<Property>
 					<Name>NcStructType</Name>
@@ -937,13 +1011,16 @@ External Setpoint Generation:
 			</Properties>
 			<Relations>
 				<Relation Priority="100">
-					<Type GUID="{60392271-8688-4F4C-B404-618DF106325D}">NCAXLESTRUCT_FROMPLC3</Type>
+					<Type GUID="{60392271-8688-4F4C-B404-618DF106325D}"></Type>
+				</Relation>
+				<Relation Priority="100">
+					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}"></Type>
 				</Relation>
 			</Relations>
 		</DataType>
 	</DataTypes>
 	<Project GUID="{7651416F-AC71-419B-B241-022DADC2F507}" Name="lcls_twincat_optics_plc" PrjFilePath="..\..\lcls_twincat_optics_plc\lcls_twincat_optics_plc.plcproj" TmcFilePath="..\..\lcls_twincat_optics_plc\lcls_twincat_optics_plc.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="lcls_twincat_optics_plc\lcls_twincat_optics_plc.tmc">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="lcls_twincat_optics_plc\lcls_twincat_optics_plc.tmc" TmcHash="{0A58351C-7CC1-728E-EE23-D87518888512}">
 			<Name>lcls_twincat_optics_plc Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">
@@ -960,19 +1037,19 @@ External Setpoint Generation:
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.stYupEnc</Name>
 					<Comment><![CDATA[ Encoders]]></Comment>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.stYdwnEnc</Name>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.stXupEnc</Name>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.stXdwnEnc</Name>
-					<Type GUID="{E7D8BF8B-2549-C401-85F6-34B274CA315B}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
+					<Type GUID="{DE508B70-ABB9-83DF-6AA5-FF9BDD51D9D9}" Namespace="lcls_twincat_motion">ST_RenishawAbsEnc</Type>
 				</Var>
 				<Var>
 					<Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -996,7 +1073,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M1.Axis.NcToPlc</Name>
-					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bLimitForwardEnable</Name>
@@ -1035,7 +1112,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M2.Axis.NcToPlc</Name>
-					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bLimitForwardEnable</Name>
@@ -1074,7 +1151,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M3.Axis.NcToPlc</Name>
-					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bLimitForwardEnable</Name>
@@ -1113,7 +1190,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M4.Axis.NcToPlc</Name>
-					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.bLimitForwardEnable</Name>
@@ -1152,7 +1229,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M5.Axis.NcToPlc</Name>
-					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.bLimitForwardEnable</Name>
@@ -1191,7 +1268,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M6.Axis.NcToPlc</Name>
-					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.bLimitForwardEnable</Name>
@@ -1230,23 +1307,23 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m6.fbDriveVirtual.MasterAxis.NcToPlc</Name>
-					<Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
+					<Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC">NCTOPLC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
@@ -1258,7 +1335,7 @@ External Setpoint Generation:
 				<Name>PlcTask Outputs</Name>
 				<Var>
 					<Name>Main.M1.Axis.PlcToNc</Name>
-					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M1.bBrakeRelease</Name>
@@ -1267,7 +1344,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M2.Axis.PlcToNc</Name>
-					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M2.bBrakeRelease</Name>
@@ -1276,7 +1353,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M3.Axis.PlcToNc</Name>
-					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M3.bBrakeRelease</Name>
@@ -1285,7 +1362,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M4.Axis.PlcToNc</Name>
-					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M4.bBrakeRelease</Name>
@@ -1294,7 +1371,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M5.Axis.PlcToNc</Name>
-					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M5.bBrakeRelease</Name>
@@ -1303,7 +1380,7 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.M6.Axis.PlcToNc</Name>
-					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.M6.bBrakeRelease</Name>
@@ -1312,23 +1389,23 @@ External Setpoint Generation:
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 				<Var>
 					<Name>Main.fbMotionStage_m6.fbDriveVirtual.MasterAxis.PlcToNc</Name>
-					<Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC">PLCTONC_AXIS_REF</Type>
+					<Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC">PLCTONC_AXIS_REF</Type>
 				</Var>
 			</Vars>
 			<Vars VarGrpType="8" AreaNo="4">

--- a/lcls-twincat-optics/lcls-twincat-optics.tsproj
+++ b/lcls-twincat-optics/lcls-twincat-optics.tsproj
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.12">
+<TcSmProject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.35" TcVersionFixed="true">
 	<Project ProjectGUID="{79189941-065E-4A00-8170-A30C306E2106}" Target64Bit="true" ShowHideConfigurations="#x306">
 		<System>
 			<Tasks>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/DUTs/DUT_HOMS.TcDUT
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/DUTs/DUT_HOMS.TcDUT
@@ -3,62 +3,62 @@
   <DUT Name="DUT_HOMS" Id="{0a6ad08f-c6e6-47f2-ab1c-db91063eb2d4}">
     <Declaration><![CDATA[TYPE DUT_HOMS :
 STRUCT
-	// System initializiation
-	fbRunHOMS : FB_RunHOMS;
+    // System initializiation
+    fbRunHOMS : FB_RunHOMS;
 
-	// Couple/Decouple motors
-	{attribute 'pytmc' := '
-		pv: COUPLE_Y
-		io: o
-	'}
-	bExecuteCoupleY : BOOL;
-	{attribute 'pytmc' := '
-		pv: DECOUPLE_Y
-		io: o
-	'}
-	bExecuteDecoupleY : BOOL;
-	{attribute 'pytmc' := '
-		pv: COUPLE_X
-		io: o
-	'}
-	bExecuteCoupleX : BOOL;
-	{attribute 'pytmc' := '
-		pv: DECOUPLE_X
-		io: o
-	'}
-	bExecuteDecoupleX : BOOL;
+    // Couple/Decouple motors
+    {attribute 'pytmc' := '
+        pv: COUPLE_Y
+        io: o
+    '}
+    bExecuteCoupleY : BOOL;
+    {attribute 'pytmc' := '
+        pv: DECOUPLE_Y
+        io: o
+    '}
+    bExecuteDecoupleY : BOOL;
+    {attribute 'pytmc' := '
+        pv: COUPLE_X
+        io: o
+    '}
+    bExecuteCoupleX : BOOL;
+    {attribute 'pytmc' := '
+        pv: DECOUPLE_X
+        io: o
+    '}
+    bExecuteDecoupleX : BOOL;
 
-	// Coupling status
-	{attribute 'pytmc' := '
-		pv: ALREADY_COUPLED_Y
-		io: i
+    // Coupling status
+    {attribute 'pytmc' := '
+        pv: ALREADY_COUPLED_Y
+        io: i
         field: ZSV MAJOR
-	'}
-	bGantryAlreadyCoupledY : BOOL;
-	{attribute 'pytmc' := '
-		pv: ALREADY_COUPLED_X
-		io: i
+    '}
+    bGantryAlreadyCoupledY : BOOL;
+    {attribute 'pytmc' := '
+        pv: ALREADY_COUPLED_X
+        io: i
         field: ZSV MAJOR
-	'}
-	bGantryAlreadyCoupledX : BOOL;
+    '}
+    bGantryAlreadyCoupledX : BOOL;
 
-	// Current gantry differences
-	nCurrGantryY : LINT; // encoder counts = nm
-	nCurrGantryX : LINT; // encoder counts = nm
+    // Current gantry differences
+    nCurrGantryY : LINT; // encoder counts = nm
+    nCurrGantryX : LINT; // encoder counts = nm
 
-	// Convert gantry differences to um (smaller number) to readout in epics
-	{attribute 'pytmc' := '
-		pv: GANTRY_Y
-		field: EGU um
-		io: i
-	'}
-	fCurrGantryY_um : REAL; // Y Gantry difference in um
-	{attribute 'pytmc' := '
-		pv: GANTRY_X
-		field: EGU um
-		io: i
-	'}
-	fCurrGantryX_um : REAL; // X Gantry difference in um
+    // Convert gantry differences to um (smaller number) to readout in epics
+    {attribute 'pytmc' := '
+        pv: GANTRY_Y
+        field: EGU um
+        io: i
+    '}
+    fCurrGantryY_um : REAL; // Y Gantry difference in um
+    {attribute 'pytmc' := '
+        pv: GANTRY_X
+        field: EGU um
+        io: i
+    '}
+    fCurrGantryX_um : REAL; // X Gantry difference in um
 END_STRUCT
 END_TYPE]]></Declaration>
   </DUT>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/DUTs/E_PiezoControl.TcDUT
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/DUTs/E_PiezoControl.TcDUT
@@ -3,14 +3,14 @@
   <DUT Name="E_PiezoControl" Id="{6f128950-a190-46f1-a0ed-00eddd22f261}">
     <Declaration><![CDATA[TYPE E_PiezoControl :
 (
-	//Piezo Control Machine
-	EPC_Idle := 0,
-	EPC_Init := 10,
-	EPC_MoveRequested  := 50,
-	EPC_MovingPositive := 100,
-	EPC_MovingNegative := 200,
-	EPC_MoveCompleted  := 350,
-	EPC_Error := 500
+    //Piezo Control Machine
+    EPC_Idle := 0,
+    EPC_Init := 10,
+    EPC_MoveRequested  := 50,
+    EPC_MovingPositive := 100,
+    EPC_MovingNegative := 200,
+    EPC_MoveCompleted  := 350,
+    EPC_Error := 500
 );
 END_TYPE
 ]]></Declaration>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/DUTs/E_PitchControl.TcDUT
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/DUTs/E_PitchControl.TcDUT
@@ -3,21 +3,21 @@
   <DUT Name="E_PitchControl" Id="{15e5f421-b8c8-457a-9ec3-ba6c1bfbee8f}">
     <Declaration><![CDATA[TYPE E_PitchControl :
 (
-	//Pitch Control Machine
-	PCM_Init := 0,
-	PCM_Standby := 1,
-	PCM_MoveRequested := 10,
-	PCM_Coarse50Piezo	:= 20,
-	PCM_CoarseMove	:= 21,
-	PCM_CoarseMoveCleanup := 22,
-	PCM_FineMove	:= 30,
-	PCM_Halt		:= 50,
-	PCM_Done	:= 8000, //why is 8000 done? Where did this come from??
-	PCM_Error   := 9000, //Anything above 9000 is considered an error
-	PCM_StepperError	:= 9100,
-	PCM_PiezoError	:= 9200,
-	PCM_OtherError := 9300,
-	PCM_STOHit := 9400
+    //Pitch Control Machine
+    PCM_Init := 0,
+    PCM_Standby := 1,
+    PCM_MoveRequested := 10,
+    PCM_Coarse50Piezo	:= 20,
+    PCM_CoarseMove	:= 21,
+    PCM_CoarseMoveCleanup := 22,
+    PCM_FineMove	:= 30,
+    PCM_Halt		:= 50,
+    PCM_Done	:= 8000, //why is 8000 done? Where did this come from??
+    PCM_Error   := 9000, //Anything above 9000 is considered an error
+    PCM_StepperError	:= 9100,
+    PCM_PiezoError	:= 9200,
+    PCM_OtherError := 9300,
+    PCM_STOHit := 9400
 );
 END_TYPE
 ]]></Declaration>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/DUTs/HOMS_PitchMechanism.TcDUT
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/DUTs/HOMS_PitchMechanism.TcDUT
@@ -3,22 +3,22 @@
   <DUT Name="HOMS_PitchMechanism" Id="{47ab44fa-385a-4709-a811-d01bc2afbb1a}">
     <Declaration><![CDATA[TYPE HOMS_PitchMechanism :
 STRUCT
-	Piezo	:	ST_PiezoAxis;	//Piezo
+    Piezo	:	ST_PiezoAxis;	//Piezo
 
-	(* Soft limits, egu urad *)
-	ReqPosLimHi	:	REAL;
-	ReqPosLimLo	:	REAL;
+    (* Soft limits, egu urad *)
+    ReqPosLimHi	:	REAL;
+    ReqPosLimLo	:	REAL;
 
 
-	(* Hard limits, egu INC *)
-	(* These are discovered during installation, and represent encoder ticks, unbiased *)
-	(* We changed to these when our pitch mechanism limit switches were insufficient for
-	good control. They had too much hysteresis/ lack of precision. At this point the limit
-	switches are ignored, and instead their function is carried out by these. *)
-	diEncPosLimHi	:	LINT;
-	diEncPosLimLo	:	LINT;
-	//Raw encoder count
-	diEncCnt	AT %I*	:	LINT;
+    (* Hard limits, egu INC *)
+    (* These are discovered during installation, and represent encoder ticks, unbiased *)
+    (* We changed to these when our pitch mechanism limit switches were insufficient for
+    good control. They had too much hysteresis/ lack of precision. At this point the limit
+    switches are ignored, and instead their function is carried out by these. *)
+    diEncPosLimHi	:	LINT;
+    diEncPosLimLo	:	LINT;
+    //Raw encoder count
+    diEncCnt	AT %I*	:	LINT;
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/DUTs/ST_PiezoAxis.TcDUT
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/DUTs/ST_PiezoAxis.TcDUT
@@ -3,46 +3,46 @@
   <DUT Name="ST_PiezoAxis" Id="{94081b12-5a5d-4193-a69e-fd329da2319a}">
     <Declaration><![CDATA[TYPE ST_PiezoAxis :
 STRUCT
-	(* IO *)
-		//Readback
-		sIdn				:	STRING; //Identity
-		iCurError			:	INT; //Current error code, should be 0 most of the time
-		iLastError			:	INT; //Last error code, for history
-		rActVoltage			:	REAL; //Actual voltage
-		rLastReqVoltage		:	REAL; //Last requested piezo voltage
-		//Control
-		rSetVoltage			:	REAL; //this parameter is set by the control loop/ voltage mode
-		sAxis				:   STRING :='A'; //Axis, e.g. A, B, C...A if single unit	
-		//Summaries
-		xTimeout	:	BOOL;
-		xDriverError		:	BOOL; //Summary of any driver errors
-	
-	(* Operation *)
-		xEnable	:	BOOL; //Enable control.
-		(* Note: Voltage mode and Idle mode overrides "DirectPiezoMode" of FB_PitchControl *)
-		xVoltageMode	:	BOOL; //Voltage mode gives direct access to piezo voltage, false means closed loop position acquisition (see FB_PitchControl for piezo and stepper separation)
-		xIdleMode	:	BOOL; //Use to put the piezo at half-stroke
-		rReqVoltage : REAL; //Requested piezo voltage in voltage mode
-		rReqAbsPos	:	LREAL; //Requested Position, latched at rising StartAbsMov
-		xStop	:	BOOL;	//Stops piezo and holds position
-	
-	
-	(* Control Parameters *)
-		rActPos	:	LREAL; //Encoder Readback
-		//Pitch piezo dmove range (urad)
-		rPiezoDmovRange		:	REAL := 1.0;
-		stPIParams	:	ST_CTRL_PI_PARAMS := (
-			tCtrlCycleTime := T#0MS,
-			tTaskCycleTime := T#0MS,
-			tTn       := T#200MS,
-			fKp      := 0.0005,
-			fOutMaxLimit := 1,
-			fOutMinLimit := -1,
-			bARWOnIPartOnly := FALSE);
+    (* IO *)
+        //Readback
+        sIdn				:	STRING; //Identity
+        iCurError			:	INT; //Current error code, should be 0 most of the time
+        iLastError			:	INT; //Last error code, for history
+        rActVoltage			:	REAL; //Actual voltage
+        rLastReqVoltage		:	REAL; //Last requested piezo voltage
+        //Control
+        rSetVoltage			:	REAL; //this parameter is set by the control loop/ voltage mode
+        sAxis				:   STRING :='A'; //Axis, e.g. A, B, C...A if single unit
+        //Summaries
+        xTimeout	:	BOOL;
+        xDriverError		:	BOOL; //Summary of any driver errors
 
-	(* Voltage ranges, come from specifications of the driver *)
-		UpperVoltage	:	REAL := GVL_Constants.cPiezoMaxVoltage; // E-816 has no software limits
-		LowerVoltage	:	REAL := GVL_Constants.cPiezoMinVoltage; // E-816 has no software limits
+    (* Operation *)
+        xEnable	:	BOOL; //Enable control.
+        (* Note: Voltage mode and Idle mode overrides "DirectPiezoMode" of FB_PitchControl *)
+        xVoltageMode	:	BOOL; //Voltage mode gives direct access to piezo voltage, false means closed loop position acquisition (see FB_PitchControl for piezo and stepper separation)
+        xIdleMode	:	BOOL; //Use to put the piezo at half-stroke
+        rReqVoltage : REAL; //Requested piezo voltage in voltage mode
+        rReqAbsPos	:	LREAL; //Requested Position, latched at rising StartAbsMov
+        xStop	:	BOOL;	//Stops piezo and holds position
+
+
+    (* Control Parameters *)
+        rActPos	:	LREAL; //Encoder Readback
+        //Pitch piezo dmove range (urad)
+        rPiezoDmovRange		:	REAL := 1.0;
+        stPIParams	:	ST_CTRL_PI_PARAMS := (
+            tCtrlCycleTime := T#0MS,
+            tTaskCycleTime := T#0MS,
+            tTn       := T#200MS,
+            fKp      := 0.0005,
+            fOutMaxLimit := 1,
+            fOutMinLimit := -1,
+            bARWOnIPartOnly := FALSE);
+
+    (* Voltage ranges, come from specifications of the driver *)
+        UpperVoltage	:	REAL := GVL_Constants.cPiezoMaxVoltage; // E-816 has no software limits
+        LowerVoltage	:	REAL := GVL_Constants.cPiezoMinVoltage; // E-816 has no software limits
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/GVLs/GVL_Constants.TcGVL
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/GVLs/GVL_Constants.TcGVL
@@ -3,10 +3,10 @@
   <GVL Name="GVL_Constants" Id="{7aa67172-25b3-4e6c-90f4-628372b0226d}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 VAR_GLOBAL CONSTANT
-	nGANTRY_TOLERANCE_NM_DEFAULT : LINT := 50000; // default gantry tolerance in encoder counts = nm
-	cPiezoMaxVoltage	:	LREAL := 120; // in Volts
-	cPiezoMinVoltage	:	LREAL := -10; // in Volts
-	cPiezoRange : REAL := 60.0; // From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are
+    nGANTRY_TOLERANCE_NM_DEFAULT : LINT := 50000; // default gantry tolerance in encoder counts = nm
+    cPiezoMaxVoltage	:	LREAL := 120; // in Volts
+    cPiezoMinVoltage	:	LREAL := -10; // in Volts
+    cPiezoRange : REAL := 60.0; // From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are
 END_VAR]]></Declaration>
   </GVL>
 </TcPlcObject>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/GVLs/GVL_TestStructs.TcGVL
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/GVLs/GVL_TestStructs.TcGVL
@@ -3,10 +3,10 @@
   <GVL Name="GVL_TestStructs" Id="{197d9202-dd0f-43a8-a9c2-c3e9ba80d67e}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 VAR_GLOBAL
-	TestPitch_LimitSwitches : HOMS_PitchMechanism := (ReqPosLimHi:=2000,
-		                                              ReqPosLimLo:=-2000,
-		                                              diEncPosLimHi:=10768330,
-		                                              diEncPosLimLo:=8141680);
+    TestPitch_LimitSwitches : HOMS_PitchMechanism := (ReqPosLimHi:=2000,
+                                                      ReqPosLimLo:=-2000,
+                                                      diEncPosLimHi:=10768330,
+                                                      diEncPosLimLo:=8141680);
 END_VAR]]></Declaration>
   </GVL>
 </TcPlcObject>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_Bender.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_Bender.TcPOU
@@ -3,9 +3,9 @@
   <POU Name="FB_Bender" Id="{d1d24e90-e8bb-4e37-9db9-9aec40d6deb9}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_Bender
 VAR_IN_OUT
-	stBender : DUT_MotionStage;
-	bSTOEnable1 : BOOL;
-	bSTOEnable2 : BOOL;
+    stBender : DUT_MotionStage;
+    bSTOEnable1 : BOOL;
+    bSTOEnable2 : BOOL;
 END_VAR
 VAR_INPUT
 END_VAR

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_Bender.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_Bender.TcPOU
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="FB_Bender" Id="{d1d24e90-e8bb-4e37-9db9-9aec40d6deb9}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_Bender
 VAR_IN_OUT
-    stBender : DUT_MotionStage;
+    stBender : ST_MotionStage;
     bSTOEnable1 : BOOL;
     bSTOEnable2 : BOOL;
 END_VAR

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_HomsStats.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_HomsStats.TcPOU
@@ -15,42 +15,42 @@ VAR
 
     fbDataYGantryDiff : FB_LREALBuffer; // YGantry Data Acquisition FB
     fbDataXGantryDiff : FB_LREALBuffer; // XGantry Data Acquisition FB
-    
+
     fbYGantryStats : FB_BasicStats; // Calculate mean/standard deviation of YGantryDiff
     fbXGantryStats : FB_BasicStats; // Calculate mean/standard deviation of XGantryDiff
     {attribute 'pytmc' := '
-		pv: YGANDIFFMEAN
-		io: i
+        pv: YGANDIFFMEAN
+        io: i
     '}
-	fYGantryDiffMean : LREAL;
-	{attribute 'pytmc' := '
-		pv: YGANDIFFSTDEV
-		io: i
-    '}
-	fYGantryDiffStDev : LREAL;
-        {attribute 'pytmc' := '
-		pv: XGANDIFFMEAN
-		io: i
-    '}
-	fXGantryDiffMean : LREAL;
-	{attribute 'pytmc' := '
-		pv: XGANDIFFSTDEV
-		io: i
-    '}
-	fXGantryDiffStDev : LREAL;
-    
-    bNewEncArray : BOOL;
-    
+    fYGantryDiffMean : LREAL;
     {attribute 'pytmc' := '
-		pv: YGANDIFFARRAY
-		io: i
+        pv: YGANDIFFSTDEV
+        io: i
     '}
-	aYGantryDiff : ARRAY [1..1000] OF LREAL;
-	{attribute 'pytmc' := '
-		pv: XGANDIFFARRAY
-		io: i
-	'}
-	aXGantryDiff : ARRAY [1..1000] OF LREAL;
+    fYGantryDiffStDev : LREAL;
+        {attribute 'pytmc' := '
+        pv: XGANDIFFMEAN
+        io: i
+    '}
+    fXGantryDiffMean : LREAL;
+    {attribute 'pytmc' := '
+        pv: XGANDIFFSTDEV
+        io: i
+    '}
+    fXGantryDiffStDev : LREAL;
+
+    bNewEncArray : BOOL;
+
+    {attribute 'pytmc' := '
+        pv: YGANDIFFARRAY
+        io: i
+    '}
+    aYGantryDiff : ARRAY [1..1000] OF LREAL;
+    {attribute 'pytmc' := '
+        pv: XGANDIFFARRAY
+        io: i
+    '}
+    aXGantryDiff : ARRAY [1..1000] OF LREAL;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -60,26 +60,26 @@ fEncXScale := fbUpStreamX.stAxisParameters.fEncScaleFactorNumerator / fbUpstream
 
 // Gantry Diff Readback/Storage
 fbDataYGantryDiff(bExecute:=True,
-           	 fInput:= LINT_TO_LREAL(homs.nCurrGantryY),
-           	 arrOutput=>aYGantryDiff,
+                fInput:= LINT_TO_LREAL(homs.nCurrGantryY),
+                arrOutput=>aYGantryDiff,
              bNewArray=>bNewEncArray);
-             
-fbDataXGantryDiff(bExecute:=True,
-           	 fInput:= LINT_TO_LREAL(homs.nCurrGantryX),
-           	 arrOutput=>aXGantryDiff,
-             bNewArray=>bNewEncArray);
-             
-fbYGantryStats(aSignal:=aYGantryDiff,
-	    bAlwaysCalc:=TRUE,
-		fMean=>fYGantryDiffMean,
-		fStDev=>fYGantryDiffStDev);
-        
-fbXGantryStats(aSignal:=aXGantryDiff,
-	    bAlwaysCalc:=TRUE,
-		fMean=>fXGantryDiffMean,
-		fStDev=>fXGantryDiffStDev);
 
-//scale outputs to actual values       
+fbDataXGantryDiff(bExecute:=True,
+                fInput:= LINT_TO_LREAL(homs.nCurrGantryX),
+                arrOutput=>aXGantryDiff,
+             bNewArray=>bNewEncArray);
+
+fbYGantryStats(aSignal:=aYGantryDiff,
+        bAlwaysCalc:=TRUE,
+        fMean=>fYGantryDiffMean,
+        fStDev=>fYGantryDiffStDev);
+
+fbXGantryStats(aSignal:=aXGantryDiff,
+        bAlwaysCalc:=TRUE,
+        fMean=>fXGantryDiffMean,
+        fStDev=>fXGantryDiffStDev);
+
+//scale outputs to actual values
 fYGantryDiffMean := fbYGantryStats.fMean * fEncYScale;
 fYGantryDiffStDev := fbYGantryStats.fStDev * fEncYScale;
 fXGantryDiffMean := fbXGantryStats.fMean * fEncXScale;

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_HomsStats.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_HomsStats.TcPOU
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="FB_HomsStats" Id="{33be0616-40a1-4f3c-b4ac-66894bf0192b}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_HomsStats
 VAR_INPUT
     homs : DUT_HOMS;
-    fbUpStreamY : DUT_MotionStage;
-    fbUpStreamX : DUT_MotionStage;
+    fbUpStreamY : ST_MotionStage;
+    fbUpStreamX : ST_MotionStage;
 END_VAR
 VAR_OUTPUT
 END_VAR

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_PiezoControl.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_PiezoControl.TcPOU
@@ -3,51 +3,51 @@
   <POU Name="FB_PiezoControl" Id="{0c3d171e-6759-449c-9e69-236d43fd29fc}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_PiezoControl
 VAR_IN_OUT
-	iq_Piezo	:	ST_PiezoAxis;
+    iq_Piezo	:	ST_PiezoAxis;
 END_VAR
 VAR_INPUT
-	xExecute	:	BOOL; //Rising edge being piezo motion
-	xReset      :   BOOL;
-	Enable_Positive : BOOL; //Reverse of Positive Limit Switch
-	Enable_Negative : BOOL; //Reverse of Negative Limit Switch
+    xExecute	:	BOOL; //Rising edge being piezo motion
+    xReset      :   BOOL;
+    Enable_Positive : BOOL; //Reverse of Positive Limit Switch
+    Enable_Negative : BOOL; //Reverse of Negative Limit Switch
 END_VAR
 VAR_OUTPUT
-	xBusy	:	BOOL; //Busy remains true while piezo position is being adjusted
-	xDone	:	BOOL; //Reached target position
-	xError	:	BOOL; //General error
-	xLimited:	BOOL; //Piezo move was limited
+    xBusy	:	BOOL; //Busy remains true while piezo position is being adjusted
+    xDone	:	BOOL; //Reached target position
+    xError	:	BOOL; //General error
+    xLimited:	BOOL; //Piezo move was limited
 END_VAR
 VAR
-	E_State     : E_PiezoControl; //ENUM for Piezo Control State
-	rtStartMove : R_TRIG; //Rising Trigger for Execution
-	rtReset     : R_TRIG; //Rising Trigger for Error reset
-	rSetpoint   : REAL;   //Internal Storage of Setpoint
-	rReqVoltage	:	REAL; //requested voltage
-	rLLSV: REAL := 0;
-	rHLSV: REAL := 120;
-	fbPI: FB_CTRL_PI;
-	fbRamp: FB_CTRL_RAMP_GENERATOR_EXT;
-	// FB initialized flag
-	bInitialized: BOOL;
-	//Get cycle time for control FBs
-	fbGetCycleTime	:	FB_CTRL_GET_TASK_CYCLETIME;
-	tTaskCycleTime: TIME;
-	bCycleTimeValid: BOOL;
-	rtVoltMode: R_TRIG;
-	fOut: LREAL;
-	fPiezoBias: LREAL := 60;
-	fScale: REAL := -60;
-	tonPiezoDone: TON := (PT:=T#2S);
-	tonPiezoLimited: TON := (PT:=T#500MS);
-	xVoltageLimited: BOOL;
-	ftEnPos	:	F_TRIG;
-	ftEnNeg	:	F_TRIG;
-	rtEnPos	:	R_TRIG;
-	rtEnNeg	:	R_TRIG;
-	fOutLimitHolder	:	LREAL; //holds the limit value until restored
-	fOutHiLimHolder	:	LREAL; //holds the limit value until restored
-	fOutLoLimHolder	:	LREAL; //holds the limit value until restored
-	xFirstPass 	: 	BOOL := TRUE;
+    E_State     : E_PiezoControl; //ENUM for Piezo Control State
+    rtStartMove : R_TRIG; //Rising Trigger for Execution
+    rtReset     : R_TRIG; //Rising Trigger for Error reset
+    rSetpoint   : REAL;   //Internal Storage of Setpoint
+    rReqVoltage	:	REAL; //requested voltage
+    rLLSV: REAL := 0;
+    rHLSV: REAL := 120;
+    fbPI: FB_CTRL_PI;
+    fbRamp: FB_CTRL_RAMP_GENERATOR_EXT;
+    // FB initialized flag
+    bInitialized: BOOL;
+    //Get cycle time for control FBs
+    fbGetCycleTime	:	FB_CTRL_GET_TASK_CYCLETIME;
+    tTaskCycleTime: TIME;
+    bCycleTimeValid: BOOL;
+    rtVoltMode: R_TRIG;
+    fOut: LREAL;
+    fPiezoBias: LREAL := 60;
+    fScale: REAL := -60;
+    tonPiezoDone: TON := (PT:=T#2S);
+    tonPiezoLimited: TON := (PT:=T#500MS);
+    xVoltageLimited: BOOL;
+    ftEnPos	:	F_TRIG;
+    ftEnNeg	:	F_TRIG;
+    rtEnPos	:	R_TRIG;
+    rtEnNeg	:	R_TRIG;
+    fOutLimitHolder	:	LREAL; //holds the limit value until restored
+    fOutHiLimHolder	:	LREAL; //holds the limit value until restored
+    fOutLoLimHolder	:	LREAL; //holds the limit value until restored
+    xFirstPass 	: 	BOOL := TRUE;
 END_VAR
 
 ]]></Declaration>
@@ -56,15 +56,15 @@ END_VAR
 
 //Triggers
 ///////////////////////////////
-	rtStartMove(CLK:=xExecute);
-	rtReset(CLK:=iq_Piezo.xEnable);
-	rtVoltMode(CLK:=iq_Piezo.xVoltageMode);
+    rtStartMove(CLK:=xExecute);
+    rtReset(CLK:=iq_Piezo.xEnable);
+    rtVoltMode(CLK:=iq_Piezo.xVoltageMode);
 
 //Status bits
 ///////////////////////////
 xBusy S= rtStartMove.Q;
 xDone R= rtStartMove.Q;
-	
+
 //Keep requested voltage to within limits
 iq_Piezo.rReqVoltage := LIMIT(iq_Piezo.LowerVoltage, iq_Piezo.rReqVoltage, iq_Piezo.UpperVoltage);
 
@@ -75,92 +75,92 @@ ftEnNeg(CLK:=Enable_Negative);
 rtEnPos(CLK:=Enable_Positive);
 rtEnNeg(CLK:=Enable_Negative);
 IF xFirstPass THEN
-	//Want to hold the limits on first pass if a switch is hit.
-	(* When we move off the limit, we'll restore the init value (usually 1). This will be reset
-	to something less than 1 when the limit gets tripped again, because presumably the actual limit
-	would have been set at a value < 1 if the system had been runing.
-	We just need to hold the init value to make it past this edge case that is present at startup. *)
-	IF NOT Enable_Positive THEN fOutHiLimHolder := iq_Piezo.stPIParams.fOutMaxLimit; END_IF
-	IF NOT Enable_Negative THEN fOutLoLimHolder := iq_Piezo.stPIParams.fOutMinLimit; END_IF
+    //Want to hold the limits on first pass if a switch is hit.
+    (* When we move off the limit, we'll restore the init value (usually 1). This will be reset
+    to something less than 1 when the limit gets tripped again, because presumably the actual limit
+    would have been set at a value < 1 if the system had been runing.
+    We just need to hold the init value to make it past this edge case that is present at startup. *)
+    IF NOT Enable_Positive THEN fOutHiLimHolder := iq_Piezo.stPIParams.fOutMaxLimit; END_IF
+    IF NOT Enable_Negative THEN fOutLoLimHolder := iq_Piezo.stPIParams.fOutMinLimit; END_IF
 ELSE
-	IF ftEnPos.Q THEN
-		rLLSV := iq_Piezo.rSetVoltage;
-		fOutHiLimHolder := iq_Piezo.stPIParams.fOutMaxLimit;
-		iq_Piezo.stPIParams.fOutMaxLimit := fbPI.fOut;
-	ELSIF rtEnPos.Q THEN
-		rLLSV := iq_Piezo.LowerVoltage;
-		iq_Piezo.stPIParams.fOutMaxLimit := fOutHiLimHolder;
-	END_IF
+    IF ftEnPos.Q THEN
+        rLLSV := iq_Piezo.rSetVoltage;
+        fOutHiLimHolder := iq_Piezo.stPIParams.fOutMaxLimit;
+        iq_Piezo.stPIParams.fOutMaxLimit := fbPI.fOut;
+    ELSIF rtEnPos.Q THEN
+        rLLSV := iq_Piezo.LowerVoltage;
+        iq_Piezo.stPIParams.fOutMaxLimit := fOutHiLimHolder;
+    END_IF
 
-	IF ftEnNeg.Q THEN
-		rHLSV := iq_Piezo.rSetVoltage;
-		
-		fOutLoLimHolder := iq_Piezo.stPIParams.fOutMinLimit;
-		iq_Piezo.stPIParams.fOutMinLimit := fbPI.fOut;
-	ELSIF rtEnNeg.Q THEN
-		rHLSV := iq_Piezo.UpperVoltage;
-		iq_Piezo.stPIParams.fOutMinLimit := fOutLoLimHolder;
-	END_IF
+    IF ftEnNeg.Q THEN
+        rHLSV := iq_Piezo.rSetVoltage;
+
+        fOutLoLimHolder := iq_Piezo.stPIParams.fOutMinLimit;
+        iq_Piezo.stPIParams.fOutMinLimit := fbPI.fOut;
+    ELSIF rtEnNeg.Q THEN
+        rHLSV := iq_Piezo.UpperVoltage;
+        iq_Piezo.stPIParams.fOutMinLimit := fOutLoLimHolder;
+    END_IF
 END_IF
 
 // Don't do anything until we're ready
 IF bInitialized THEN
-	// While the block is working, a new position may be requested, this is OK
-	IF xBusy THEN
-		fbPI.fSetpointValue := iq_Piezo.rReqAbsPos;
-	END_IF
+    // While the block is working, a new position may be requested, this is OK
+    IF xBusy THEN
+        fbPI.fSetpointValue := iq_Piezo.rReqAbsPos;
+    END_IF
 
-	(* The next chunk of code prevents the PI block from winding up.
-		First, when the PI block begins to request a voltage that is 
-		beyond the permitted range (this range is affected by the state
-		of limit switches/ or enable fwd/bwd), we latch the requested position.
-		Presumeably this position request  *)
+    (* The next chunk of code prevents the PI block from winding up.
+        First, when the PI block begins to request a voltage that is
+        beyond the permitted range (this range is affected by the state
+        of limit switches/ or enable fwd/bwd), we latch the requested position.
+        Presumeably this position request  *)
 
-	//Select the PI block control mode
-	////////////////////////////////////////
-	IF iq_Piezo.xVoltageMode THEN
-		//Set PI block to idle
-		fbPI.eMode := eCTRL_MODE_PASSIVE;
-		rReqVoltage := iq_Piezo.rReqVoltage; //TODO add a ramp
-	ELSE
-		IF iq_Piezo.xIdleMode THEN
-			rReqVoltage := fScale * 0 + fPiezoBias;
+    //Select the PI block control mode
+    ////////////////////////////////////////
+    IF iq_Piezo.xVoltageMode THEN
+        //Set PI block to idle
+        fbPI.eMode := eCTRL_MODE_PASSIVE;
+        rReqVoltage := iq_Piezo.rReqVoltage; //TODO add a ramp
+    ELSE
+        IF iq_Piezo.xIdleMode THEN
+            rReqVoltage := fScale * 0 + fPiezoBias;
 
-			fbPI.eMode := eCTRL_MODE_MANUAL;
-			ACT_Controller();
-			fbPI.bHold := TRUE;
-		ELSE
-			//Fout is connected to the piezo voltage control
-			rReqVoltage := fScale * fbPI.fOut + fPiezoBias;
-			fbPI.bHold := FALSE;
-			//Control mode is always active, so compensation takes over more smoothly
-			fbPI.eMode := eCTRL_MODE_ACTIVE;
-		END_IF		
-	
-	END_IF
+            fbPI.eMode := eCTRL_MODE_MANUAL;
+            ACT_Controller();
+            fbPI.bHold := TRUE;
+        ELSE
+            //Fout is connected to the piezo voltage control
+            rReqVoltage := fScale * fbPI.fOut + fPiezoBias;
+            fbPI.bHold := FALSE;
+            //Control mode is always active, so compensation takes over more smoothly
+            fbPI.eMode := eCTRL_MODE_ACTIVE;
+        END_IF
 
-	ACT_Controller();
+    END_IF
 
-	xVoltageLimited := rLLSV > rReqVoltage OR rHLSV < rReqVoltage;
+    ACT_Controller();
 
-	//This is where the voltage request gets sent to the piezo driver
-	iq_Piezo.rSetVoltage := LIMIT(rLLSV, rReqVoltage, rHLSV);
+    xVoltageLimited := rLLSV > rReqVoltage OR rHLSV < rReqVoltage;
+
+    //This is where the voltage request gets sent to the piezo driver
+    iq_Piezo.rSetVoltage := LIMIT(rLLSV, rReqVoltage, rHLSV);
 
 //Initialization
 ELSE
-	fbGetCycleTime( eMode   := eCTRL_MODE_ACTIVE,
+    fbGetCycleTime( eMode   := eCTRL_MODE_ACTIVE,
                 tTaskCycleTime => tTaskCycleTime,
                 bCycleTimeValid => bCycleTimeValid);
-	IF bCycleTimeValid THEN
-		iq_Piezo.stPIParams.tTaskCycleTime := tTaskCycleTime;
-		iq_Piezo.stPIParams.tCtrlCycleTime := tTaskCycleTime;
-		bInitialized	:= TRUE;
-	END_IF
+    IF bCycleTimeValid THEN
+        iq_Piezo.stPIParams.tTaskCycleTime := tTaskCycleTime;
+        iq_Piezo.stPIParams.tCtrlCycleTime := tTaskCycleTime;
+        bInitialized	:= TRUE;
+    END_IF
 
 END_IF
 
-tonPiezoDone.IN := WithinRange(ValA:=iq_Piezo.rActPos, Center:=iq_Piezo.rReqAbsPos, Range:=iq_Piezo.rPiezoDmovRange, Offset:=0) 
-					AND NOT rtStartMove.Q; //rtStartMove interrupts the timer, resetting it
+tonPiezoDone.IN := WithinRange(ValA:=iq_Piezo.rActPos, Center:=iq_Piezo.rReqAbsPos, Range:=iq_Piezo.rPiezoDmovRange, Offset:=0)
+                    AND NOT rtStartMove.Q; //rtStartMove interrupts the timer, resetting it
 tonPiezoDone();
 
 tonPiezoLimited.IN := (fbPI.bARWactive OR xVoltageLimited) AND NOT rtStartMove.Q;

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_PitchControl.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_PitchControl.TcPOU
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.6">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="FB_PitchControl" Id="{143b5005-3e50-4e14-8a6a-21db919333f0}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_PitchControl
 VAR_IN_OUT
     Pitch : HOMS_PitchMechanism;
-    Stepper : DUT_MotionStage;
+    Stepper : ST_MotionStage;
 END_VAR
 VAR_INPUT
-    lrCurrentSetpoint : LREAL; // Setpoint: Epics writes to DUT_MotionStage which gets fed into this
+    lrCurrentSetpoint : LREAL; // Setpoint: Epics writes to ST_MotionStage which gets fed into this
 END_VAR
 VAR_OUTPUT
     q_bError : BOOL;

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_RMSWatch.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_RMSWatch.TcPOU
@@ -5,59 +5,59 @@
 VAR_INPUT
 END_VAR
 VAR_OUTPUT
-	// RMS Error
-	fMaxRMSError : LREAL := 0;
-	fMinRMSError : LREAL := 1000; // start at something huge, FB will update with any smaller measured value
+    // RMS Error
+    fMaxRMSError : LREAL := 0;
+    fMinRMSError : LREAL := 1000; // start at something huge, FB will update with any smaller measured value
 END_VAR
 VAR_IN_OUT
-	stMotionStage : DUT_MotionStage;
+    stMotionStage : DUT_MotionStage;
 END_VAR
 VAR
     fEncScalingNum : LREAL := 1.0;
     fEncScalingDenom : LREAL := 1.0;
     fEncOffset : LREAL := 0;
     fEncScale : LREAL := 1.0;
-    
-	fbDataEncPos : FB_LREALBuffer; // ActPos Data Acquisition FB
-	fbDataSetPos : FB_LREALBuffer; // SetPos Data Acquisition FB
-	bExecuteDataStorage : BOOL := TRUE; // Take data of both ActPos and SetPos
-	bNewEncArray : BOOL;
 
-	fbStats : FB_BasicStats; // Calculate mean/standard deviation of ActPos
-	{attribute 'pytmc' := '
-		pv: MEAN
-		io: i
-    '}
-	fEncMean : LREAL;
-	{attribute 'pytmc' := '
-		pv: STDEV
-		io: i
-    '}
-	fEncStDev : LREAL;
-	{attribute 'pytmc' := '
-		pv: RMS
-		io: i
-    '}
-	fCurrRMSError : LREAL := 0;
+    fbDataEncPos : FB_LREALBuffer; // ActPos Data Acquisition FB
+    fbDataSetPos : FB_LREALBuffer; // SetPos Data Acquisition FB
+    bExecuteDataStorage : BOOL := TRUE; // Take data of both ActPos and SetPos
+    bNewEncArray : BOOL;
 
-	nIndex : DINT;
-	fSum : LREAL := 0; // Just for calculating rms
-	fDiff : LREAL := 0;
-
-	{attribute 'pytmc' := '
-		pv: ACTPOSARRAY
-		io: i
+    fbStats : FB_BasicStats; // Calculate mean/standard deviation of ActPos
+    {attribute 'pytmc' := '
+        pv: MEAN
+        io: i
     '}
-	aEncActPos : ARRAY [1..1000] OF LREAL;
-	{attribute 'pytmc' := '
-		pv: SETPOSARRAY
-		io: i
-	'}
-	aEncSetPos : ARRAY [1..1000] OF LREAL;
+    fEncMean : LREAL;
+    {attribute 'pytmc' := '
+        pv: STDEV
+        io: i
+    '}
+    fEncStDev : LREAL;
+    {attribute 'pytmc' := '
+        pv: RMS
+        io: i
+    '}
+    fCurrRMSError : LREAL := 0;
+
+    nIndex : DINT;
+    fSum : LREAL := 0; // Just for calculating rms
+    fDiff : LREAL := 0;
+
+    {attribute 'pytmc' := '
+        pv: ACTPOSARRAY
+        io: i
+    '}
+    aEncActPos : ARRAY [1..1000] OF LREAL;
+    {attribute 'pytmc' := '
+        pv: SETPOSARRAY
+        io: i
+    '}
+    aEncSetPos : ARRAY [1..1000] OF LREAL;
 END_VAR
 ]]></Declaration>
     <Implementation>
-      <ST><![CDATA[// Encoder Scaling 
+      <ST><![CDATA[// Encoder Scaling
 fEncScalingNum := stMotionStage.stAxisParameters.fEncScaleFactorNumerator;
 fEncScalingDenom := stMotionStage.stAxisParameters.fEncScaleFactorDenominator;
 fEncOffset := stMotionStage.stAxisParameters.fEncOffset;
@@ -66,38 +66,38 @@ fEncScale := fEncScalingNum / fEncScalingDenom;
 // FB to store encoder positions in 1000 element arrays, compute RMS errors, and watch for min/max
 // Encoder Readback/Storage
 fbDataEncPos(bExecute:=bExecuteDataStorage,
-           	 fInput:= ULINT_TO_LREAL(stMotionStage.nRawEncoderULINT),
-           	 arrOutput=>aEncActPos,
+                fInput:= ULINT_TO_LREAL(stMotionStage.nRawEncoderULINT),
+                arrOutput=>aEncActPos,
              bNewArray=>bNewEncArray);
 
 fbDataSetPos(bExecute:=bExecuteDataStorage,
-         	 fInput:=(stMotionStage.Axis.NcToPlc.SetPos - fEncOffset) / fEncScale,
-           	 arrOutput=>aEncSetPos);
+              fInput:=(stMotionStage.Axis.NcToPlc.SetPos - fEncOffset) / fEncScale,
+                arrOutput=>aEncSetPos);
 
 fbStats(aSignal:=aEncActPos,
-	    bAlwaysCalc:=TRUE,
-		fMean=>fEncMean,
-		fStDev=>fEncStDev);
+        bAlwaysCalc:=TRUE,
+        fMean=>fEncMean,
+        fStDev=>fEncStDev);
 
 // Calculate RMS Error:
 If bNewEncArray THEN
-	fCurrRMSError := 0;
-	FOR nIndex := 2 TO 1000 DO
-		// First point in array stuck as 0 for some reason...
-		fDiff := aEncActPos[nIndex] - aEncSetPos[nIndex];
-		fSum := EXPT(fDiff, 2);
-		fCurrRMSError := fCurrRMSError + fSum;
-	END_FOR;
-	fCurrRMSError := fCurrRMSError / 999.0; // 1000 element array but ditched the first point
-	fCurrRMSError := SQRT(fCurrRMSError);
-	// Watch for max:
-	IF fCurrRMSError > fMaxRMSError THEN
-		fMaxRMSError := fCurrRMSError;
-	END_IF
-	// Watch for min:
-	IF fCurrRMSError < fMinRMSError THEN
-		fMinRMSError := fCurrRMSError;
-	END_IF
+    fCurrRMSError := 0;
+    FOR nIndex := 2 TO 1000 DO
+        // First point in array stuck as 0 for some reason...
+        fDiff := aEncActPos[nIndex] - aEncSetPos[nIndex];
+        fSum := EXPT(fDiff, 2);
+        fCurrRMSError := fCurrRMSError + fSum;
+    END_FOR;
+    fCurrRMSError := fCurrRMSError / 999.0; // 1000 element array but ditched the first point
+    fCurrRMSError := SQRT(fCurrRMSError);
+    // Watch for max:
+    IF fCurrRMSError > fMaxRMSError THEN
+        fMaxRMSError := fCurrRMSError;
+    END_IF
+    // Watch for min:
+    IF fCurrRMSError < fMinRMSError THEN
+        fMinRMSError := fCurrRMSError;
+    END_IF
     fCurrRMSError := fCurrRMSError * fEncScale;
     fMaxRMSError := FMaxRMSError * fEncScale;
     fMinRMSError := FMinRMSError * fEncScale;

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_RMSWatch.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_RMSWatch.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="FB_RMSWatch" Id="{7d0ac4a7-0c5c-406a-a694-5de5f07477d4}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_RMSWatch
 VAR_INPUT
@@ -10,7 +10,7 @@ VAR_OUTPUT
     fMinRMSError : LREAL := 1000; // start at something huge, FB will update with any smaller measured value
 END_VAR
 VAR_IN_OUT
-    stMotionStage : DUT_MotionStage;
+    stMotionStage : ST_MotionStage;
 END_VAR
 VAR
     fEncScalingNum : LREAL := 1.0;

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_RunHOMS.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_RunHOMS.TcPOU
@@ -3,54 +3,54 @@
   <POU Name="FB_RunHOMS" Id="{ee7498ff-903e-47a0-a649-7587adeefcee}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_RunHOMS
 VAR_INPUT
-	// Encoder Reference Values
-	nYupEncRef : ULINT;
-	nYdwnEncRef : ULINT;
-	nXupEncRef : ULINT;
-	nXdwnEncRef : ULINT;
+    // Encoder Reference Values
+    nYupEncRef : ULINT;
+    nYdwnEncRef : ULINT;
+    nXupEncRef : ULINT;
+    nXdwnEncRef : ULINT;
 
-	// Gantry Tolerances
-	nGantryTolY : LINT := GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT; // Encoder counts = nm
-	nGantryTolX : LINT := GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT; // Encoder counts = nm
+    // Gantry Tolerances
+    nGantryTolY : LINT := GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT; // Encoder counts = nm
+    nGantryTolX : LINT := GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT; // Encoder counts = nm
 END_VAR
 VAR_OUTPUT
-	// Gantry coupling status
-	bGantryAlreadyCoupledY : BOOL;
-	bGantryAlreadyCoupledX : BOOL;
-	
-	// Current gantry difference
-	nCurrGantryY : LINT;
-	nCurrGantryX : LINT;
+    // Gantry coupling status
+    bGantryAlreadyCoupledY : BOOL;
+    bGantryAlreadyCoupledX : BOOL;
+
+    // Current gantry difference
+    nCurrGantryY : LINT;
+    nCurrGantryX : LINT;
 END_VAR
 VAR_IN_OUT
-	// Motor Structs
-	stYup : DUT_MotionStage;
-	stYdwn : DUT_MotionStage;
-	stXup : DUT_MotionStage;
-	stXdwn : DUT_MotionStage;
-	stPitch : DUT_MotionStage;
+    // Motor Structs
+    stYup : DUT_MotionStage;
+    stYdwn : DUT_MotionStage;
+    stXup : DUT_MotionStage;
+    stXdwn : DUT_MotionStage;
+    stPitch : DUT_MotionStage;
 
-	// Manual coupling Gantried Axes
-	bExecuteCoupleY : BOOL;
-	bExecuteCoupleX : BOOL;
-	bExecuteDecoupleY : BOOL;
-	bExecuteDecoupleX : BOOL;
+    // Manual coupling Gantried Axes
+    bExecuteCoupleY : BOOL;
+    bExecuteCoupleX : BOOL;
+    bExecuteDecoupleY : BOOL;
+    bExecuteDecoupleX : BOOL;
 END_VAR
 VAR
-	// STO Button
-	bSTOEnable1 AT %I* : BOOL;
-	bSTOEnable2 AT %I* : BOOL;
+    // STO Button
+    bSTOEnable1 AT %I* : BOOL;
+    bSTOEnable2 AT %I* : BOOL;
 
-	// Encoders
-	stYupEnc AT %I* : ST_RenishawAbsEnc;
-	stYdwnEnc AT %I* : ST_RenishawAbsEnc;
-	
-	stXupEnc AT %I* : ST_RenishawAbsEnc;
-	stXdwnEnc AT %I* : ST_RenishawAbsEnc;
+    // Encoders
+    stYupEnc AT %I* : ST_RenishawAbsEnc;
+    stYdwnEnc AT %I* : ST_RenishawAbsEnc;
 
-	// Autocoupling Gantried Axes
-	fbAutoCoupleY : FB_GantryAutoCoupling;
-	fbAutoCoupleX : FB_GantryAutoCoupling;
+    stXupEnc AT %I* : ST_RenishawAbsEnc;
+    stXdwnEnc AT %I* : ST_RenishawAbsEnc;
+
+    // Autocoupling Gantried Axes
+    fbAutoCoupleY : FB_GantryAutoCoupling;
+    fbAutoCoupleX : FB_GantryAutoCoupling;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Encoder Reference Values
@@ -72,22 +72,22 @@ stPitch.bHardwareEnable := bSTOEnable1 AND bSTOEnable2;
 
 // Start Autocoupling
 fbAutoCoupleY(nGantryTol:=nGantryTolY,
-	          Master:=stYup,
-			  MasterEnc:= stYupEnc,
-			  Slave:=stYdwn,
-			  SlaveEnc:=stYdwnEnc,
-			  bExecuteCouple:=bExecuteCoupleY,
-			  bExecuteDecouple:=bExecuteDecoupleY,
-			  bGantryAlreadyCoupled=>bGantryAlreadyCoupledY);
+              Master:=stYup,
+              MasterEnc:= stYupEnc,
+              Slave:=stYdwn,
+              SlaveEnc:=stYdwnEnc,
+              bExecuteCouple:=bExecuteCoupleY,
+              bExecuteDecouple:=bExecuteDecoupleY,
+              bGantryAlreadyCoupled=>bGantryAlreadyCoupledY);
 
 fbAutoCoupleX(nGantryTol:=nGantryTolX,
-	          Master:=stXup,
-			  MasterEnc:= stXupEnc,
-			  Slave:=stXdwn,
-			  SlaveEnc:=stXdwnEnc,
-			  bExecuteCouple:=bExecuteCoupleX,
-			  bExecuteDecouple:=bExecuteDecoupleX,
-			  bGantryAlreadyCoupled=>bGantryAlreadyCoupledX);]]></ST>
+              Master:=stXup,
+              MasterEnc:= stXupEnc,
+              Slave:=stXdwn,
+              SlaveEnc:=stXdwnEnc,
+              bExecuteCouple:=bExecuteCoupleX,
+              bExecuteDecouple:=bExecuteDecoupleX,
+              bGantryAlreadyCoupled=>bGantryAlreadyCoupledX);]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_RunHOMS.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_RunHOMS.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="FB_RunHOMS" Id="{ee7498ff-903e-47a0-a649-7587adeefcee}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_RunHOMS
 VAR_INPUT
@@ -24,11 +24,11 @@ VAR_OUTPUT
 END_VAR
 VAR_IN_OUT
     // Motor Structs
-    stYup : DUT_MotionStage;
-    stYdwn : DUT_MotionStage;
-    stXup : DUT_MotionStage;
-    stXdwn : DUT_MotionStage;
-    stPitch : DUT_MotionStage;
+    stYup : ST_MotionStage;
+    stYdwn : ST_MotionStage;
+    stXup : ST_MotionStage;
+    stXdwn : ST_MotionStage;
+    stPitch : ST_MotionStage;
 
     // Manual coupling Gantried Axes
     bExecuteCoupleY : BOOL;

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_RunHOMSWithBender.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/FB_RunHOMSWithBender.TcPOU
@@ -7,17 +7,17 @@ END_VAR
 VAR_OUTPUT
 END_VAR
 VAR_IN_OUT
-	stYup : DUT_MotionStage;
-	stYdwn : DUT_MotionStage;
-	stXup : DUT_MotionStage;
-	stXdwn : DUT_MotionStage;
-	stPitch : DUT_MotionStage;
-	stBender : DUT_MotionStage;
+    stYup : DUT_MotionStage;
+    stYdwn : DUT_MotionStage;
+    stXup : DUT_MotionStage;
+    stXdwn : DUT_MotionStage;
+    stPitch : DUT_MotionStage;
+    stBender : DUT_MotionStage;
 
-	bExecuteCoupleY : BOOL;
-	bExecuteCoupleX : BOOL;
-	bExecuteDecoupleY : BOOL;
-	bExecuteDecoupleX : BOOL;
+    bExecuteCoupleY : BOOL;
+    bExecuteCoupleX : BOOL;
+    bExecuteDecoupleY : BOOL;
+    bExecuteDecoupleX : BOOL;
 END_VAR
 VAR
 END_VAR

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
@@ -20,7 +20,7 @@ VAR_INPUT
 
     bReadPmpsDb : BOOL; // Trigger a re-read of the JSON Beam Parameters
 
-    bUsePmpsDb : BOOL := FALSE; // Set TRUE to lookup Beam Parameteres via DB.
+    bUsePmpsDb : BOOL := FALSE; // Set TRUE to lookup Beam Parameters via DB.
 END_VAR
 VAR_OUTPUT
 END_VAR

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
@@ -21,6 +21,10 @@ VAR_INPUT
     bReadPmpsDb : BOOL; // Trigger a re-read of the JSON Beam Parameters
 
     bUsePmpsDb : BOOL := FALSE; // Set TRUE to lookup Beam Parameters via DB.
+
+    nUpperCoatingBitmask : DWORD := 0;
+
+    nLowerCoatingBitMask : DWORD := 0;
 END_VAR
 VAR_OUTPUT
 END_VAR
@@ -45,9 +49,6 @@ VAR
     fbGetCoatingBPs : FB_JsonDocToSafeBP;
     ftReadJsonDocDone : F_TRIG;
     bBPsLoaded : BOOL := FALSE;
-
-    nUpperCoatingBitmask : DWORD := 0;
-    nLowerCoatingBitMask : DWORD := 0;
 
     i : INT;
     sDevState : STRING  := '';

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="FB_MirrorTwoCoatingProtection" Id="{e481ed92-d77f-4692-a2ea-e5f1d2863716}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_MirrorTwoCoatingProtection
 VAR_INPUT
@@ -28,12 +28,16 @@ END_VAR
 VAR
     ffUpperCoating: FB_FastFault := (
         i_xAutoReset := FALSE,
-        i_TypeCode := 16#401);
+        i_TypeCode := 16#401,
+        i_Desc := ' mirror coating incompatible with beam photon energy');
     ffLowerCoating : FB_FastFault := (
         i_xAutoReset := FALSE,
-        i_TypeCode := 16#401);
-    sFFBeamParamMismatch : STRING := ' mirror coating incompatible with beam photon energy';
-    sFFBeamParamNotLoaded : STRING := ' mirror coating beam parameters not loaded';
+        i_TypeCode := 16#401,
+        i_Desc := ' mirror coating incompatible with beam photon energy');
+    ffBeamParamsNotLoaded : FB_FastFault := (
+        i_xAutoReset := TRUE,
+        i_TypeCode := 16#488,
+        i_Desc := ' mirror coating beam parameters not loaded');
 
     aDbStateParams : ARRAY[0..1] OF ST_DbStateParams;
     fbGetCoatingBPs : FB_JsonDocToSafeBP;
@@ -84,19 +88,9 @@ IF ftReadJsonDocDone.Q AND NOT fbGetCoatingBps.bError THEN
     bBPsLoaded := TRUE;
 END_IF
 
-IF bBPsLoaded THEN
-    ffUpperCoating.i_Desc := CONCAT(sUpperCoatingType, sFFBeamParamMismatch);
-    ffLowerCoating.i_Desc := CONCAT(sLowerCoatingType, sFFBeamParamMismatch);
 
-    nUpperCoatingBitmask := aDbStateParams[0].stBeamParams.neVRange;
-    nLowerCoatingBitMask := aDbStateParams[1].stBeamParams.neVRange;
-ELSE
-    ffUpperCoating.i_Desc := CONCAT(sUpperCoatingType, sFFBeamParamNotLoaded);
-    ffLowerCoating.i_Desc := CONCAT(sLowerCoatingType, sFFBeamParamNotLoaded);
-
-    nUpperCoatingBitmask := 0;
-    nLowerCoatingBitMask := 0;
-END_IF
+nUpperCoatingBitmask := aDbStateParams[0].stBeamParams.neVRange;
+nLowerCoatingBitMask := aDbStateParams[1].stBeamParams.neVRange;
 
 IF nCurrentEncoderCount <= nLowerCoatingBoundary THEN
     ffLowerCoating.i_xOK := (neVRange AND nLowerCoatingBitMask) = neVRange;
@@ -109,8 +103,11 @@ ELSE
     ffUpperCoating.i_xOK := FALSE;
 END_IF
 
+ffBeamParamsNotLoaded.i_xOK := bBPsLoaded;
+
 ffUpperCoating(io_fbFFHWO:=FFO, i_xAutoReset := bAutoClear);
-ffLowerCoating(io_fbFFHWO:=FFO, i_xAutoReset := bAutoClear);]]></ST>
+ffLowerCoating(io_fbFFHWO:=FFO, i_xAutoReset := bAutoClear);
+ffBeamParamsNotLoaded(io_fbFFHWO:=FFO);]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
@@ -20,7 +20,7 @@ VAR_INPUT
 
     bReadPmpsDb : BOOL; // Trigger a re-read of the JSON Beam Parameters
 
-    bUsePmpsDb : BOOL := FALSE;
+    bUsePmpsDb : BOOL := FALSE; // Set TRUE to lookup Beam Parameteres via DB.
 END_VAR
 VAR_OUTPUT
 END_VAR

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
@@ -19,6 +19,8 @@ VAR_INPUT
     bAutoClear : BOOL := TRUE; // Auto-clear these fast faults
 
     bReadPmpsDb : BOOL; // Trigger a re-read of the JSON Beam Parameters
+
+    bUsePmpsDb : BOOL := FALSE;
 END_VAR
 VAR_OUTPUT
 END_VAR
@@ -56,41 +58,46 @@ END_VAR
       <ST><![CDATA[IF NOT bInit THEN
     ffUpperCoating.i_DevName := sDevName;
     ffLowerCoating.i_DevName := sDevName;
-
-    FOR i:=0 to 1 BY 1 DO
-        sDevState := CONCAT(sDevState, sDevName);
-        sDevState := CONCAT(sDevState, '-');
-        CASE i OF
-        0:
-            sDevState := CONCAT(sDevState, sUpperCoatingType);
-        1:
-            sDevState := CONCAT(sDevState, sLowerCoatingType);
-        END_CASE
-        aDbStateParams[i].sPmpsState := sDevState;
-        sDevState := '';
-    END_FOR
+    IF bUsePmpsDb THEN
+        FOR i:=0 to 1 BY 1 DO
+            sDevState := CONCAT(sDevState, sDevName);
+            sDevState := CONCAT(sDevState, '-');
+            CASE i OF
+            0:
+                sDevState := CONCAT(sDevState, sUpperCoatingType);
+            1:
+                sDevState := CONCAT(sDevState, sLowerCoatingType);
+            END_CASE
+            aDbStateParams[i].sPmpsState := sDevState;
+            sDevState := '';
+        END_FOR
+    ELSE
+        bBPsLoaded := TRUE;
+    END_IF
     bInit := TRUE;
 END_IF
 
-IF bReadPmpsDB THEN
-    bBPsLoaded := FALSE;
-END_IF
+IF bUsePmpsDb THEN
+    IF bReadPmpsDB THEN
+        bBPsLoaded := FALSE;
+    END_IF
 
-fbGetCoatingBPs(bExecute := bReadPmpsDB,
-    jsonDoc := PMPS_GVL.BP_jsonDoc,
-    sDeviceName:=sDevName,
-    io_fbFFHWO:=FFO,
-    arrStates := aDbStateParams);
+    fbGetCoatingBPs(bExecute := bReadPmpsDB,
+        jsonDoc := PMPS_GVL.BP_jsonDoc,
+        sDeviceName:=sDevName,
+        io_fbFFHWO:=FFO,
+        arrStates := aDbStateParams);
 
-ftReadJsonDocDone(CLK:=fbGetCoatingBPs.bBusy);
+    ftReadJsonDocDone(CLK:=fbGetCoatingBPs.bBusy);
 
-IF ftReadJsonDocDone.Q AND NOT fbGetCoatingBps.bError THEN
-    bBPsLoaded := TRUE;
-END_IF
+    IF ftReadJsonDocDone.Q AND NOT fbGetCoatingBps.bError THEN
+        bBPsLoaded := TRUE;
+    END_IF
 
-IF bBPsLoaded THEN
-    nUpperCoatingBitmask := aDbStateParams[0].stBeamParams.neVRange;
-    nLowerCoatingBitMask := aDbStateParams[1].stBeamParams.neVRange;
+    IF bBPsLoaded THEN
+        nUpperCoatingBitmask := aDbStateParams[0].stBeamParams.neVRange;
+        nLowerCoatingBitMask := aDbStateParams[1].stBeamParams.neVRange;
+    END_IF
 END_IF
 
 IF nCurrentEncoderCount <= nLowerCoatingBoundary THEN

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU
@@ -88,9 +88,10 @@ IF ftReadJsonDocDone.Q AND NOT fbGetCoatingBps.bError THEN
     bBPsLoaded := TRUE;
 END_IF
 
-
-nUpperCoatingBitmask := aDbStateParams[0].stBeamParams.neVRange;
-nLowerCoatingBitMask := aDbStateParams[1].stBeamParams.neVRange;
+IF bBPsLoaded THEN
+    nUpperCoatingBitmask := aDbStateParams[0].stBeamParams.neVRange;
+    nLowerCoatingBitMask := aDbStateParams[1].stBeamParams.neVRange;
+END_IF
 
 IF nCurrentEncoderCount <= nLowerCoatingBoundary THEN
     ffLowerCoating.i_xOK := (neVRange AND nLowerCoatingBitMask) = neVRange;

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/MC_SmoothMover.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/MC_SmoothMover.TcPOU
@@ -3,25 +3,25 @@
   <POU Name="MC_SmoothMover" Id="{49439872-0161-4fd4-9e7f-62bcb9508941}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK MC_SmoothMover
 VAR_IN_OUT
-	Axis	:	AXIS_REF;
+    Axis	:	AXIS_REF;
 END_VAR
 VAR_INPUT
-	Velocity : LREAL;
-	ReqAbsPos : LREAL; //New requested position
-	Enable	:	BOOL; //While true the block will accept new positions and attempt to move to them if they are different
-	Execute	:	BOOL; //Will retry a move if the target position is the same
+    Velocity : LREAL;
+    ReqAbsPos : LREAL; //New requested position
+    Enable	:	BOOL; //While true the block will accept new positions and attempt to move to them if they are different
+    Execute	:	BOOL; //Will retry a move if the target position is the same
 END_VAR
 VAR_OUTPUT
-	Done	:	BOOL;
-	Busy	:	BOOL;
-	Error	:	BOOL;
+    Done	:	BOOL;
+    Busy	:	BOOL;
+    Error	:	BOOL;
 END_VAR
 VAR
-	mcMoveAbsolute : ARRAY[1..2] OF MC_MoveAbsolute;
-	iI: INT;
-	imcBlockIndex: INT;
-	ReqAbsPosPrevious	: LREAL;
-	rtExecute: R_TRIG;
+    mcMoveAbsolute : ARRAY[1..2] OF MC_MoveAbsolute;
+    iI: INT;
+    imcBlockIndex: INT;
+    ReqAbsPosPrevious	: LREAL;
+    rtExecute: R_TRIG;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -37,21 +37,21 @@ can be used to retry a move. Axis must be enabled by a power block.
 rtExecute(CLK:=Execute);
 
 IF ( (ReqAbsPos <> ReqAbsPosPrevious AND Enable) OR rtExecute.Q) THEN
-			mcMoveAbsolute[imcBlockIndex].Execute := FALSE;
-			imcBlockIndex := imcBlockIndex + 1;
-			IF imcBlockIndex >2 THEN imcBlockIndex := 1; END_IF
-			mcMoveAbsolute[imcBlockIndex].Position := ReqAbsPos;
-			mcMoveAbsolute[imcBlockIndex].Execute := TRUE;
-			ReqAbsPosPrevious := ReqAbsPos;
-		ELSIF mcMoveAbsolute[imcBlockIndex].Done OR 
-				mcMoveAbsolute[imcBlockIndex].CommandAborted OR 
-				mcMoveAbsolute[imcBlockIndex].Busy OR 
-				mcMoveAbsolute[imcBlockIndex].Error THEN
-			mcMoveAbsolute[imcBlockIndex].Execute := FALSE;
-		END_IF
-		
+            mcMoveAbsolute[imcBlockIndex].Execute := FALSE;
+            imcBlockIndex := imcBlockIndex + 1;
+            IF imcBlockIndex >2 THEN imcBlockIndex := 1; END_IF
+            mcMoveAbsolute[imcBlockIndex].Position := ReqAbsPos;
+            mcMoveAbsolute[imcBlockIndex].Execute := TRUE;
+            ReqAbsPosPrevious := ReqAbsPos;
+        ELSIF mcMoveAbsolute[imcBlockIndex].Done OR
+                mcMoveAbsolute[imcBlockIndex].CommandAborted OR
+                mcMoveAbsolute[imcBlockIndex].Busy OR
+                mcMoveAbsolute[imcBlockIndex].Error THEN
+            mcMoveAbsolute[imcBlockIndex].Execute := FALSE;
+        END_IF
+
 FOR iI := 1 TO 2 DO
-	mcMoveAbsolute[iI](Axis := Axis, Velocity:=Velocity, BufferMode:=MC_Aborting);
+    mcMoveAbsolute[iI](Axis := Axis, Velocity:=Velocity, BufferMode:=MC_Aborting);
 END_FOR
 
 Error := mcMoveAbsolute[1].Error OR mcMoveAbsolute[2].Error;

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/WithinRange.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/WithinRange.TcPOU
@@ -3,21 +3,21 @@
   <POU Name="WithinRange" Id="{665d2067-503e-41d4-add4-3ba7efc451a5}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION WithinRange : BOOL
 VAR_INPUT
-	ValA	:	REAL; //New position to evaluate
-	Center :	REAL; //Current position
-	Range : REAL; //Span of the range
-	Offset	:	REAL := 0; //Offset from center if the range is non-symetric
+    ValA	:	REAL; //New position to evaluate
+    Center :	REAL; //Current position
+    Range : REAL; //Span of the range
+    Offset	:	REAL := 0; //Offset from center if the range is non-symetric
 END_VAR
 VAR
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[IF ValA < (Center + Offset - (Range/2) ) THEN
-	WithinRange := FALSE;
+    WithinRange := FALSE;
 ELSIF ValA > (Center + Offset + (Range/2) ) THEN
-	WithinRange := FALSE;
+    WithinRange := FALSE;
 ELSE
-	WithinRange := TRUE;
+    WithinRange := TRUE;
 END_IF]]></ST>
     </Implementation>
   </POU>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Main.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Main.TcPOU
@@ -3,32 +3,32 @@
   <POU Name="Main" Id="{bced800e-adc0-4347-8ec8-808d3a0afec0}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM Main
 VAR
-	(*
-	// Test Pitch Control
-	fbPitchControl : FB_PitchControl;
-	TestPitch : HOMS_PitchMechanism := (ReqPosLimHi:=2000,
-		                                ReqPosLimLo:=-2000,
-		                                diEncPosLimHi:=10768330,
-		                                diEncPosLimLo:=8141680);
-	M1 : DUT_MotionStage;
-	bPitchDone : BOOL;
-	*)
+    (*
+    // Test Pitch Control
+    fbPitchControl : FB_PitchControl;
+    TestPitch : HOMS_PitchMechanism := (ReqPosLimHi:=2000,
+                                        ReqPosLimLo:=-2000,
+                                        diEncPosLimHi:=10768330,
+                                        diEncPosLimLo:=8141680);
+    M1 : DUT_MotionStage;
+    bPitchDone : BOOL;
+    *)
 
-	// Test Bender vs No Bender
-	TESTWithBender : DUT_HOMS;
-	M1 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
-	M2 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
-	M3 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
-	M4 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
-	M5 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
-	M6 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
-	fbBender : FB_Bender;
+    // Test Bender vs No Bender
+    TESTWithBender : DUT_HOMS;
+    M1 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
+    M2 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
+    M3 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
+    M4 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
+    M5 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
+    M6 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
+    fbBender : FB_Bender;
 
-	fbMotionStage_m1 : FB_MotionStage;
-	fbMotionStage_m2 : FB_MotionStage;
-	fbMotionStage_m3 : FB_MotionStage;
-	fbMotionStage_m4 : FB_MotionStage;
-	fbMotionStage_m6 : FB_MotionStage;
+    fbMotionStage_m1 : FB_MotionStage;
+    fbMotionStage_m2 : FB_MotionStage;
+    fbMotionStage_m3 : FB_MotionStage;
+    fbMotionStage_m4 : FB_MotionStage;
+    fbMotionStage_m6 : FB_MotionStage;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -39,12 +39,12 @@ M1.bLimitForwardEnable;
 M1.bHardwareEnable;
 M1.fVelocity := 150.0;
 fbPitchControl(Pitch:=TestPitch,
-			   Stepper:=M1,
-			   lrCurrentSetpoint:=M1.fPosition,
-			   q_bDone=>bPitchDone,
-			   q_bBusy=>);
+               Stepper:=M1,
+               lrCurrentSetpoint:=M1.fPosition,
+               q_bDone=>bPitchDone,
+               q_bBusy=>);
 IF NOT M1.bHardwareEnable THEN
-	M1.fPosition := M1.stAxisStatus.fActPosition;
+    M1.fPosition := M1.stAxisStatus.fActPosition;
 END_IF
 *)
 
@@ -78,21 +78,21 @@ TESTWithBender.fbRunHOMS(stYup:=M1,
                          stXup:=M3,
                          stXdwn:=M4,
                          stPitch:=M5,
-	                     nYupEncRef:=0,
+                         nYupEncRef:=0,
                          nYdwnEncRef:=0,
                          nXupEncRef:=0,
                          nXdwnEncRef:=0,
-			             bExecuteCoupleY:=TESTWithBender.bExecuteCoupleY,
+                         bExecuteCoupleY:=TESTWithBender.bExecuteCoupleY,
                          bExecuteCoupleX:=TESTWithBender.bExecuteCoupleX,
-			             bExecuteDecoupleY:=TESTWithBender.bExecuteDecoupleY,
+                         bExecuteDecoupleY:=TESTWithBender.bExecuteDecoupleY,
                          bExecuteDecoupleX:=TESTWithBender.bExecuteDecoupleX,
                          bGantryAlreadyCoupledY=>TESTWithBender.bGantryAlreadyCoupledY,
                          bGantryAlreadyCoupledX=>TESTWithBender.bGantryAlreadyCoupledX,
                          nCurrGantryY=>TESTWithBender.nCurrGantryY,
                          nCurrGantryX=>TESTWithBender.nCurrGantryX);
 fbBender(stBender:=M6,
-	     bSTOEnable1:=TESTWithBender.fbRunHOMS.bSTOEnable1,
-		 bSTOEnable2:=TESTWithBender.fbRunHOMS.bSTOEnable2);
+         bSTOEnable1:=TESTWithBender.fbRunHOMS.bSTOEnable1,
+         bSTOEnable2:=TESTWithBender.fbRunHOMS.bSTOEnable2);
 
 fbMotionStage_m1(stMotionStage:=M1);
 fbMotionStage_m2(stMotionStage:=M2);

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Main.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Main.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="Main" Id="{bced800e-adc0-4347-8ec8-808d3a0afec0}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM Main
 VAR
@@ -10,18 +10,18 @@ VAR
                                         ReqPosLimLo:=-2000,
                                         diEncPosLimHi:=10768330,
                                         diEncPosLimLo:=8141680);
-    M1 : DUT_MotionStage;
+    M1 : ST_MotionStage;
     bPitchDone : BOOL;
     *)
 
     // Test Bender vs No Bender
     TESTWithBender : DUT_HOMS;
-    M1 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
-    M2 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
-    M3 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
-    M4 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
-    M5 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
-    M6 : DUT_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
+    M1 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
+    M2 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
+    M3 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
+    M4 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
+    M5 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
+    M6 : ST_MotionStage := (nEnableMode:=ENUM_StageEnableMode.ALWAYS);
     fbBender : FB_Bender;
 
     fbMotionStage_m1 : FB_MotionStage;

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Tests/TEST_PitchControl.TcPOU
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Tests/TEST_PitchControl.TcPOU
@@ -16,29 +16,29 @@ END_VAR
     <Method Name="LimitSwitches" Id="{cfe4231f-d115-4318-b321-c7df49f7961e}">
       <Declaration><![CDATA[METHOD LimitSwitches
 VAR_INPUT
-    
+
 END_VAR
 VAR
     fActPosition : LREAL;
-	bPitchDone : BOOL;
+    bPitchDone : BOOL;
 END_VAR
 VAR_INST
     fbPitchControl : FB_PitchControl;
 
-	ExpertMode : BOOL := FALSE;
-	PitchManualMode : BOOL := FALSE;
-    
+    ExpertMode : BOOL := FALSE;
+    PitchManualMode : BOOL := FALSE;
+
     iStep : UINT := 0;
-    
+
     rtDone : R_TRIG;
-    
+
     tonHack : TON := (PT:=T#2s);
-    
+
 END_VAR
 VAR CONSTANT
     BwdLimPos : LREAL := -500;
     FwdLimPos : LREAL := 500;
-    
+
     ForwardTestSP : LREAL := 1000;
 END_VAR]]></Declaration>
       <Implementation>
@@ -50,14 +50,14 @@ GVL_TestStructs.TestPitch_LimitSwitches.Stepper.bHardwareEnable := TRUE;
 GVL_TestStructs.TestPitch_LimitSwitches.Stepper.fVelocity := 150.0;
 
 fbPitchControl(Pitch:=GVL_TestStructs.TestPitch_LimitSwitches,
-			   q_bDone=>bPitchDone,
-			   q_bBusy=>);
+               q_bDone=>bPitchDone,
+               q_bBusy=>);
 rtDone(CLK:=bPitchDone);
 
 tonHack(IN:=GVL_TestStructs.TestPitch_LimitSwitches.Stepper.Axis.Status.MotionState = MC_AXISSTATE_STANDSTILL);
 
-               
-TEST('PitchControlLimitSwitchTests');               
+
+TEST('PitchControlLimitSwitchTests');
 CASE iStep OF
 
 
@@ -69,9 +69,9 @@ TEST('Forward Limit Switch Stop');
 IF fActPosition > FwdLimPos AND rtDone.Q THEN
 
 //    AssertTrue(GVL_TestStructs.TestPitch_LimitSwitches.Stepper.fPosition = fActPosition, 'Setpoint did not reset to stopped position');
-	AssertTrue(GVL_TestStructs.TestPitch_LimitSwitches.Stepper.Axis.Status.MotionState = MC_AXISSTATE_STANDSTILL AND NOT GVL_TestStructs.TestPitch_LimitSwitches.Stepper.bAllForwardEnable, 'Did not stop at forward limit');
+    AssertTrue(GVL_TestStructs.TestPitch_LimitSwitches.Stepper.Axis.Status.MotionState = MC_AXISSTATE_STANDSTILL AND NOT GVL_TestStructs.TestPitch_LimitSwitches.Stepper.bAllForwardEnable, 'Did not stop at forward limit');
     TEST_FINISHED_NAMED('Forward Limit Switch Stop');
-    
+
     iStep := 20;
 END_IF
 
@@ -85,7 +85,7 @@ IF rtDone.Q THEN
 //    AssertTrue(GVL_TestStructs.TestPitch_LimitSwitches.Stepper.fPosition = GVL_TestStructs.TestPitch_LimitSwitches.Stepper.stAxisStatus.fActPosition, 'Position not at back off position');
     AssertTrue(GVL_TestStructs.TestPitch_LimitSwitches.Stepper.fPosition = fActPosition, 'Position not at back off position');
     TEST_FINISHED_NAMED('Forward Limit BO');
-    
+
     iStep := 30;
 END_IF
 
@@ -97,9 +97,9 @@ TEST('Bwd Limit Switch Stop');
 IF fActPosition > FwdLimPos AND rtDone.Q THEN
 
     AssertTrue(GVL_TestStructs.TestPitch_LimitSwitches.Stepper.fPosition = fActPosition, 'Setpoint did not reset to stopped position');
-    
+
     TEST_FINISHED_NAMED('Bwd Limit Switch Stop');
-    
+
     iStep := 50;
 END_IF
 
@@ -112,16 +112,16 @@ TEST('Bwd Limit BO');
 IF rtDone.Q THEN
 
     AssertTrue(GVL_TestStructs.TestPitch_LimitSwitches.Stepper.fPosition = fActPosition, 'Position not at back off position');
-    
+
     TEST_FINISHED_NAMED('Bwd Limit BO');
-    
+
     iStep := 8000;
 END_IF
 
 60:
 
 8000:
-TEST_FINISHED_NAMED('PitchControlLimitSwitchTests');             
+TEST_FINISHED_NAMED('PitchControlLimitSwitchTests');
 
 END_CASE]]></ST>
       </Implementation>
@@ -129,7 +129,7 @@ END_CASE]]></ST>
     <Method Name="StepperPiezoExchange" Id="{2ba91de8-e34c-4d3a-aea5-0bb97ec6666e}">
       <Declaration><![CDATA[METHOD StepperPiezoExchange
 VAR_INPUT
-    
+
 END_VAR
 VAR
     fActPosition : LREAL;
@@ -137,16 +137,16 @@ END_VAR
 VAR_INST
     fbPitchControl : FB_PitchControl;
 
-	ExpertMode : BOOL := FALSE;
-	PitchManualMode : BOOL := FALSE;
-    
+    ExpertMode : BOOL := FALSE;
+    PitchManualMode : BOOL := FALSE;
+
     iStep : UINT := 0;
-    
+
 END_VAR
 VAR CONSTANT
     BwdLimPos : LREAL := -500;
     FwdLimPos : LREAL := 500;
-    
+
     ForwardTestSP : LREAL := 1000;
 END_VAR
 ]]></Declaration>
@@ -159,10 +159,10 @@ GVL_TestStructs.TestPitch_LimitSwitches.Stepper.bHardwareEnable := TRUE;
 GVL_TestStructs.TestPitch_LimitSwitches.Stepper.fVelocity := 150.0;
 
 fbPitchControl(Pitch:=GVL_TestStructs.TestPitch_LimitSwitches,
-			   q_bDone=>,
-			   q_bBusy=>);
-               
-               
+               q_bDone=>,
+               q_bBusy=>);
+
+
 CASE iStep OF
 
 
@@ -173,7 +173,7 @@ TEST('Forward Limit Switch Stop');
 IF fActPosition > FwdLimPos AND GVL_TestStructs.TestPitch_LimitSwitches.Stepper.Axis.Status.MotionState = MC_AXISSTATE_STANDSTILL THEN
     AssertTrue(GVL_TestStructs.TestPitch_LimitSwitches.Stepper.Axis.Status.MotionState = MC_AXISSTATE_STANDSTILL, 'Axis not at standstill');
     AssertTrue(GVL_TestStructs.TestPitch_LimitSwitches.Stepper.fPosition = fActPosition, 'Setpoint did not reset to stopped position');
-    
+
     TEST_FINISHED_NAMED('Forward Limit Switch Stop');
 END_IF
 
@@ -185,7 +185,7 @@ END_IF
 
 40: // Attempt to move again past bwd limit and be denied
 
-50: // Attempt to back off limit and succeed            
+50: // Attempt to back off limit and succeed
 
 END_CASE]]></ST>
       </Implementation>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/Version/Global_Version.TcGVL
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/Version/Global_Version.TcGVL
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.6">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <GVL Name="Global_Version" Id="{f98aab9b-240c-4c69-8c0a-e5732bdbece6}">
     <Declaration><![CDATA[{attribute 'TcGenerated'}
 {attribute 'no-analysis'}
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
     {attribute 'const_non_replaced'}
-    stLibVersion_lcls_twincat_optics : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
+    stLibVersion_lcls_twincat_optics_nrw : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/Version/Global_Version.TcGVL
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
     {attribute 'const_non_replaced'}
-    stLibVersion_lcls_twincat_optics_nrw : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
+    stLibVersion_lcls_twincat_optics : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 0, iRevision := 0, nFlags := 0, sVersion := '0.0.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
@@ -16,7 +16,7 @@
     <CombineIds>false</CombineIds>
     <Company>SLAC</Company>
     <Released>false</Released>
-    <Title>lcls-twincat-optics-nrw</Title>
+    <Title>lcls-twincat-optics</Title>
     <ProjectVersion>0.0.0</ProjectVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
@@ -103,9 +103,9 @@
       <DefaultResolution>LCLS General, * (SLAC)</DefaultResolution>
       <Namespace>LCLS_General</Namespace>
     </PlaceholderReference>
-    <PlaceholderReference Include="lcls-twincat-motion-nrw">
-      <DefaultResolution>lcls-twincat-motion-nrw, * (SLAC)</DefaultResolution>
-      <Namespace>lcls_twincat_motion_nrw</Namespace>
+    <PlaceholderReference Include="lcls-twincat-motion">
+      <DefaultResolution>lcls-twincat-motion, * (SLAC)</DefaultResolution>
+      <Namespace>lcls_twincat_motion</Namespace>
     </PlaceholderReference>
     <PlaceholderReference Include="PMPS">
       <DefaultResolution>PMPS, * (SLAC - LCLS)</DefaultResolution>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
@@ -16,7 +16,7 @@
     <CombineIds>false</CombineIds>
     <Company>SLAC</Company>
     <Released>false</Released>
-    <Title>lcls-twincat-optics</Title>
+    <Title>lcls-twincat-optics-nrw</Title>
     <ProjectVersion>0.0.0</ProjectVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.plcproj
@@ -103,9 +103,9 @@
       <DefaultResolution>LCLS General, * (SLAC)</DefaultResolution>
       <Namespace>LCLS_General</Namespace>
     </PlaceholderReference>
-    <PlaceholderReference Include="lcls-twincat-motion">
-      <DefaultResolution>lcls-twincat-motion, * (SLAC)</DefaultResolution>
-      <Namespace>lcls_twincat_motion</Namespace>
+    <PlaceholderReference Include="lcls-twincat-motion-nrw">
+      <DefaultResolution>lcls-twincat-motion-nrw, * (SLAC)</DefaultResolution>
+      <Namespace>lcls_twincat_motion_nrw</Namespace>
     </PlaceholderReference>
     <PlaceholderReference Include="PMPS">
       <DefaultResolution>PMPS, * (SLAC - LCLS)</DefaultResolution>
@@ -152,9 +152,6 @@
   <ItemGroup>
     <PlaceholderResolution Include="LCLS General">
       <Resolution>LCLS General, * (SLAC)</Resolution>
-    </PlaceholderResolution>
-    <PlaceholderResolution Include="lcls-twincat-motion">
-      <Resolution>lcls-twincat-motion, * (SLAC)</Resolution>
     </PlaceholderResolution>
     <PlaceholderResolution Include="PMPS">
       <Resolution>PMPS, * (SLAC - LCLS)</Resolution>

--- a/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.tmc
+++ b/lcls-twincat-optics/lcls_twincat_optics_plc/lcls_twincat_optics_plc.tmc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{9A25EA2E-5D95-A7FF-7649-D48D723D578B}" GeneratedBy="TwinCAT XAE Plc">
+<TcModuleClass xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2009/05/TcModuleClass" Hash="{0A58351C-7CC1-728E-EE23-D87518888512}" GeneratedBy="TwinCAT XAE Plc">
   <DataTypes>
     <DataType>
       <Name Namespace="LCLS_General">ST_System</Name>
@@ -92,9 +92,9 @@
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General">E_Subsystem</Name>
+      <Comment>LCLS Defined subsystems, make sure these correspond with casSubsystems in FB_LogMessage</Comment>
       <BitSize>16</BitSize>
       <BaseType>WORD</BaseType>
-      <Comment>LCLS Defined subsystems, make sure these correspond with casSubsystems in FB_LogMessage</Comment>
       <EnumInfo>
         <Text>NILVALUE</Text>
         <Enum>0</Enum>
@@ -181,31 +181,37 @@
         <Name>bBusy</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>79590184</GetCodeOffs>
+        <GetCodeOffs>79590232</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>bError</Name>
         <Type>BOOL</Type>
         <BitSize>8</BitSize>
-        <GetCodeOffs>79590256</GetCodeOffs>
+        <GetCodeOffs>79590304</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>hrErrorCode</Name>
         <Type GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79590272</GetCodeOffs>
+        <GetCodeOffs>79590320</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nStringSize</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79590232</GetCodeOffs>
+        <GetCodeOffs>79590280</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sResult</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>79590264</GetCodeOffs>
+        <GetCodeOffs>79590312</GetCodeOffs>
+        <Properties>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
       </PropertyItem>
       <Method>
         <Name RpcEnable="plc" VTableIndex="0">__getbBusy</Name>
@@ -225,10 +231,6 @@
           <Property>
             <Name>property</Name>
           </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
         </Properties>
       </Method>
       <Method>
@@ -245,21 +247,6 @@
         </Properties>
       </Method>
       <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>GetString</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -273,16 +260,6 @@
           <Comment> buffer size in bytes</Comment>
           <Type>UDINT</Type>
           <BitSize>32</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -302,10 +279,6 @@
         <Properties>
           <Property>
             <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
           </Property>
         </Properties>
       </Method>
@@ -330,10 +303,6 @@
           <Property>
             <Name>property</Name>
           </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
         </Properties>
       </Method>
       <Method>
@@ -348,10 +317,6 @@
         <Properties>
           <Property>
             <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
           </Property>
           <Property>
             <Name>TcEncoding</Name>
@@ -376,10 +341,6 @@
         <Properties>
           <Property>
             <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
           </Property>
         </Properties>
       </Method>
@@ -593,6 +554,16 @@
       <Name Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Name>
       <BitSize>64</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <PropertyItem>
+        <Name>nId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>sName</Name>
+        <Type>STRING(255)</Type>
+        <BitSize>2048</BitSize>
+      </PropertyItem>
       <Method>
         <Name>__getguid</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000021}">GUID</ReturnType>
@@ -617,30 +588,22 @@
         </Properties>
       </Method>
       <Method>
-        <Name>__getnId</Name>
-        <ReturnType>UDINT</ReturnType>
+        <Name RpcEnable="plc" VTableIndex="3">__getnId</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
             <Name>property</Name>
           </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
         </Properties>
       </Method>
       <Method>
-        <Name>__getsName</Name>
-        <ReturnType>STRING(255)</ReturnType>
+        <Name RpcEnable="plc" VTableIndex="4">__getsName</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Properties>
           <Property>
             <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
           </Property>
           <Property>
             <Name>TcEncoding</Name>
@@ -686,17 +649,38 @@
       <Name Namespace="LCLS_General.Tc3_EventLogger">I_TcEventBase</Name>
       <BitSize>64</BitSize>
       <ExtendsType GUID="{18071995-0000-0000-0000-000000000018}">PVOID</ExtendsType>
+      <PropertyItem>
+        <Name>eSeverity</Name>
+        <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
+        <BitSize>16</BitSize>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>ipSourceInfo</Name>
+        <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
+        <BitSize>64</BitSize>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>nEventId</Name>
+        <Type>UDINT</Type>
+        <BitSize>32</BitSize>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>sEventClassName</Name>
+        <Type>STRING(255)</Type>
+        <BitSize>2048</BitSize>
+      </PropertyItem>
+      <PropertyItem>
+        <Name>sEventText</Name>
+        <Type>STRING(255)</Type>
+        <BitSize>2048</BitSize>
+      </PropertyItem>
       <Method>
-        <Name>__geteSeverity</Name>
-        <ReturnType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</ReturnType>
+        <Name RpcEnable="plc" VTableIndex="1">__geteSeverity</Name>
+        <ReturnType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}" RpcDirection="out">TcEventSeverity</ReturnType>
         <ReturnBitSize>16</ReturnBitSize>
         <Properties>
           <Property>
             <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
           </Property>
         </Properties>
       </Method>
@@ -711,44 +695,32 @@
         </Properties>
       </Method>
       <Method>
-        <Name>__getipSourceInfo</Name>
-        <ReturnType Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</ReturnType>
+        <Name RpcEnable="plc" VTableIndex="3">__getipSourceInfo</Name>
+        <ReturnType Namespace="LCLS_General.Tc3_EventLogger" RpcDirection="out">I_TcSourceInfo</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
         <Properties>
           <Property>
             <Name>property</Name>
           </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
         </Properties>
       </Method>
       <Method>
-        <Name>__getnEventId</Name>
-        <ReturnType>UDINT</ReturnType>
+        <Name RpcEnable="plc" VTableIndex="4">__getnEventId</Name>
+        <ReturnType RpcDirection="out">UDINT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
         <Properties>
           <Property>
             <Name>property</Name>
           </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
         </Properties>
       </Method>
       <Method>
-        <Name>__getsEventClassName</Name>
-        <ReturnType>STRING(255)</ReturnType>
+        <Name RpcEnable="plc" VTableIndex="5">__getsEventClassName</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Properties>
           <Property>
             <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
           </Property>
           <Property>
             <Name>TcEncoding</Name>
@@ -757,16 +729,12 @@
         </Properties>
       </Method>
       <Method>
-        <Name>__getsEventText</Name>
-        <ReturnType>STRING(255)</ReturnType>
+        <Name RpcEnable="plc" VTableIndex="6">__getsEventText</Name>
+        <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
         <Properties>
           <Property>
             <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
           </Property>
           <Property>
             <Name>TcEncoding</Name>
@@ -1489,15 +1457,21 @@
         <Name>nId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79590056</GetCodeOffs>
-        <SetCodeOffs>79590104</SetCodeOffs>
+        <GetCodeOffs>79590104</GetCodeOffs>
+        <SetCodeOffs>79590152</SetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>79590136</GetCodeOffs>
-        <SetCodeOffs>79590160</SetCodeOffs>
+        <GetCodeOffs>79590184</GetCodeOffs>
+        <SetCodeOffs>79590208</SetCodeOffs>
+        <Properties>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
       </PropertyItem>
       <Method>
         <Name>ExtendName</Name>
@@ -1543,36 +1517,7 @@
           <Property>
             <Name>property</Name>
           </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
         </Properties>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>ResetToDefault</Name>
@@ -1599,10 +1544,6 @@
         <Properties>
           <Property>
             <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
           </Property>
         </Properties>
       </Method>
@@ -1659,10 +1600,6 @@
             <Name>property</Name>
           </Property>
           <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-          <Property>
             <Name>TcEncoding</Name>
             <Value>UTF-8</Value>
           </Property>
@@ -1688,10 +1625,6 @@
         <Properties>
           <Property>
             <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
           </Property>
           <Property>
             <Name>TcEncoding</Name>
@@ -1773,37 +1706,49 @@
         <Name>eSeverity</Name>
         <Type GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</Type>
         <BitSize>16</BitSize>
-        <GetCodeOffs>79590368</GetCodeOffs>
+        <GetCodeOffs>79590416</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>ipSourceInfo</Name>
         <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcSourceInfo</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>79590328</GetCodeOffs>
+        <GetCodeOffs>79590376</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nEventId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79590504</GetCodeOffs>
+        <GetCodeOffs>79590552</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>nUniqueId</Name>
         <Type>UDINT</Type>
         <BitSize>32</BitSize>
-        <GetCodeOffs>79590512</GetCodeOffs>
+        <GetCodeOffs>79590560</GetCodeOffs>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventClassName</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>79590424</GetCodeOffs>
+        <GetCodeOffs>79590472</GetCodeOffs>
+        <Properties>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
       </PropertyItem>
       <PropertyItem>
         <Name>sEventText</Name>
         <Type>STRING(255)</Type>
         <BitSize>2048</BitSize>
-        <GetCodeOffs>79590520</GetCodeOffs>
+        <GetCodeOffs>79590568</GetCodeOffs>
+        <Properties>
+          <Property>
+            <Name>TcEncoding</Name>
+            <Value>UTF-8</Value>
+          </Property>
+        </Properties>
       </PropertyItem>
       <Method>
         <Name>EqualsToEventClass</Name>
@@ -1879,10 +1824,6 @@
           <Property>
             <Name>property</Name>
           </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
         </Properties>
       </Method>
       <Method>
@@ -1893,21 +1834,6 @@
         <Parameter>
           <Name>ipOther</Name>
           <Type Namespace="LCLS_General.Tc3_EventLogger">I_TcEventBase</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -1966,10 +1892,6 @@
         <Properties>
           <Property>
             <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
           </Property>
         </Properties>
       </Method>
@@ -2089,16 +2011,6 @@
         <Name>OnArgumentsChanged</Name>
       </Method>
       <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name RpcEnable="plc" VTableIndex="11">__getsEventClassName</Name>
         <ReturnType RpcDirection="out">STRING(255)</ReturnType>
         <ReturnBitSize>2048</ReturnBitSize>
@@ -2110,10 +2022,6 @@
         <Properties>
           <Property>
             <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
           </Property>
           <Property>
             <Name>TcEncoding</Name>
@@ -2293,10 +2201,6 @@
           <Property>
             <Name>property</Name>
           </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
         </Properties>
       </Method>
       <Method>
@@ -2322,10 +2226,6 @@
           <Property>
             <Name>property</Name>
           </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
         </Properties>
       </Method>
       <Method>
@@ -2340,10 +2240,6 @@
         <Properties>
           <Property>
             <Name>property</Name>
-          </Property>
-          <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
           </Property>
           <Property>
             <Name>TcEncoding</Name>
@@ -2439,7 +2335,13 @@
         <Name>nTimeSent</Name>
         <Type>ULINT</Type>
         <BitSize>64</BitSize>
-        <GetCodeOffs>79590576</GetCodeOffs>
+        <GetCodeOffs>79590624</GetCodeOffs>
+        <Properties>
+          <Property>
+            <Name>TcDisplayTypeGUID</Name>
+            <Value>18071995-0000-0000-0000-000000000046</Value>
+          </Property>
+        </Properties>
       </PropertyItem>
       <Method>
         <Name>SetJsonAttribute</Name>
@@ -2521,10 +2423,6 @@
             <Name>property</Name>
           </Property>
           <Property>
-            <Name>monitoring</Name>
-            <Value>call</Value>
-          </Property>
-          <Property>
             <Name>TcDisplayTypeGUID</Name>
             <Value>18071995-0000-0000-0000-000000000046</Value>
           </Property>
@@ -2566,31 +2464,6 @@
           <Type GUID="{BFC9A87A-F6DE-499A-AC45-F3B1A59315F9}">ITcArguments</Type>
           <BitSize>64</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>__getipEvent</Name>
@@ -2683,7 +2556,7 @@
         <BitSize>8</BitSize>
         <BitOffs>80</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -2691,31 +2564,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2769,31 +2617,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -2826,7 +2649,7 @@
         <BitSize>16</BitSize>
         <BitOffs>2112</BitOffs>
         <Default>
-          <Value>0</Value>
+          <EnumText>TcEventSeverity.Verbose</EnumText>
         </Default>
         <Properties>
           <Property>
@@ -2887,7 +2710,7 @@
         <BitSize>32</BitSize>
         <BitOffs>58176</BitOffs>
         <Default>
-          <Value>1</Value>
+          <DateTime>T#1ms</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -2903,7 +2726,7 @@
         <BitSize>32</BitSize>
         <BitOffs>58208</BitOffs>
         <Default>
-          <Value>100</Value>
+          <DateTime>T#100ms</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -2919,7 +2742,7 @@
         <BitSize>32</BitSize>
         <BitOffs>58240</BitOffs>
         <Default>
-          <Value>600000</Value>
+          <DateTime>T#10m</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -2935,7 +2758,7 @@
         <BitSize>8</BitSize>
         <BitOffs>58272</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -2950,7 +2773,7 @@
         <BitSize>8</BitSize>
         <BitOffs>58280</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -2959,7 +2782,7 @@
         <BitSize>8</BitSize>
         <BitOffs>58288</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -3014,7 +2837,7 @@
         <BitSize>16</BitSize>
         <BitOffs>83264</BitOffs>
         <Default>
-          <Value>0</Value>
+          <EnumText>TcEventSeverity.Verbose</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -3023,7 +2846,7 @@
         <BitSize>8</BitSize>
         <BitOffs>83280</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -3137,31 +2960,6 @@
       <Action>
         <Name>CircuitBreaker</Name>
       </Action>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -3246,9 +3044,9 @@
     </DataType>
     <DataType>
       <Name Namespace="Tc2_Utilities">E_HashPrefixTypes</Name>
+      <Comment> Integer to string format prefixes </Comment>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
-      <Comment> Integer to string format prefixes </Comment>
       <EnumInfo>
         <Text>HASHPREFIX_IEC</Text>
         <Enum>0</Enum>
@@ -3262,9 +3060,9 @@
     </DataType>
     <DataType>
       <Name Namespace="Tc2_Utilities">E_SBCSType</Name>
+      <Comment> Windows SBCS (Single Byte Character Set) Code Pages </Comment>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
-      <Comment> Windows SBCS (Single Byte Character Set) Code Pages </Comment>
       <EnumInfo>
         <Text>eSBCS_WesternEuropean</Text>
         <Enum>1</Enum>
@@ -3284,9 +3082,9 @@
     </DataType>
     <DataType>
       <Name Namespace="Tc2_Utilities">E_RouteTransportType</Name>
+      <Comment> TwinCAT route transport types </Comment>
       <BitSize>16</BitSize>
       <BaseType>UINT</BaseType>
-      <Comment> TwinCAT route transport types </Comment>
       <EnumInfo>
         <Text>eRouteTransport_None</Text>
         <Enum>0</Enum>
@@ -3389,9 +3187,9 @@
     </DataType>
     <DataType>
       <Name Namespace="Tc2_Utilities">E_ArgType</Name>
+      <Comment> String format functions/fb's argument types </Comment>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
-      <Comment> String format functions/fb's argument types </Comment>
       <EnumInfo>
         <Text>ARGTYPE_UNKNOWN</Text>
         <Enum>0</Enum>
@@ -3491,7 +3289,7 @@
         <BitSize>16</BitSize>
         <BitOffs>0</BitOffs>
         <Default>
-          <Value>0</Value>
+          <EnumText>E_ArgType.ARGTYPE_UNKNOWN</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -3736,31 +3534,6 @@
         <BitSize>32</BitSize>
         <BitOffs>224</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -4198,31 +3971,6 @@
         <ReturnType Namespace="TcUnit" ReferenceTo="true">ST_TestSuiteResults</ReturnType>
         <ReturnBitSize>64</ReturnBitSize>
       </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -4295,16 +4043,6 @@
         <BitOffs>392</BitOffs>
       </SubItem>
       <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>LogTestSuiteResults</Name>
         <Local>
           <Name>TcUnitTestResults</Name>
@@ -4342,21 +4080,6 @@
           <BitSize>648</BitSize>
         </Local>
       </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -4371,8 +4094,6 @@
     </DataType>
     <DataType>
       <Name Namespace="LCLS_General.TcUnit.SysFile">ACCESS_MODE</Name>
-      <BitSize>32</BitSize>
-      <BaseType>UDINT</BaseType>
       <Comment> | Access mode
  | File modes to open a file.
 
@@ -4386,6 +4107,8 @@
  	     SysFileRead();
  	     SysFileGetPos();
  	     SysFileWrite();</Comment>
+      <BitSize>32</BitSize>
+      <BaseType>UDINT</BaseType>
       <EnumInfo>
         <Text>AM_READ</Text>
         <Enum>0</Enum>
@@ -4446,7 +4169,7 @@
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
         <Default>
-          <Value>5</Value>
+          <EnumText>ACCESS_MODE.AM_APPEND_PLUS</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -4455,16 +4178,6 @@
         <BitSize>64</BitSize>
         <BitOffs>128</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Method>
         <Name>Read</Name>
         <Comment>
@@ -4503,21 +4216,6 @@
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>Open</Name>
@@ -4749,21 +4447,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>__getLength</Name>
         <Comment>
     Gets/Sets the current length (in bytes) of the streambuffer
@@ -4780,16 +4463,6 @@
             <Name>property</Name>
           </Property>
         </Properties>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>Clear</Name>
@@ -5147,21 +4820,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>NewTag</Name>
         <Comment>
     Creates a new Tag:
@@ -5237,16 +4895,6 @@
         </Properties>
       </Method>
       <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>NewTagData</Name>
         <Parameter>
           <Name>Data</Name>
@@ -5310,7 +4958,7 @@
         <BitSize>32</BitSize>
         <BitOffs>192</BitOffs>
         <Default>
-          <Value>4</Value>
+          <EnumText>ACCESS_MODE.AM_WRITE_PLUS</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -5331,7 +4979,7 @@
         <BitSize>8</BitSize>
         <BitOffs>6464</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -5364,16 +5012,6 @@
 </Comment>
         <ReturnType Namespace="LCLS_General.TcUnit.SysDir.SysTypes">RTS_IEC_RESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>LogTestSuiteResults</Name>
@@ -5415,21 +5053,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>Initialised</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -5454,7 +5077,7 @@
         <BitSize>8</BitSize>
         <BitOffs>64</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -5527,34 +5150,9 @@
         <BitOffs>621828224</BitOffs>
       </SubItem>
       <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AbortRunningTestSuiteTests</Name>
         <Comment> This function sets a flag which makes the runner stop running the tests
    in the test suites </Comment>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>RunTestSuiteTestsInSequence</Name>
@@ -5696,21 +5294,6 @@
         <BitOffs>4216</BitOffs>
       </SubItem>
       <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>GetAssertionType</Name>
         <ReturnType Namespace="TcUnit">E_AssertionType</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -5737,16 +5320,6 @@
           <Name>NoOfAssertions</Name>
           <Type>UINT</Type>
           <BitSize>16</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Method>
@@ -6052,31 +5625,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -6115,31 +5663,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -6152,9 +5675,9 @@
     </DataType>
     <DataType>
       <Name Namespace="Tc2_Utilities">E_TypeFieldParam</Name>
+      <Comment> String format argument types </Comment>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
-      <Comment> String format argument types </Comment>
       <EnumInfo>
         <Text>TYPEFIELD_UNKNOWN</Text>
         <Enum>0</Enum>
@@ -6622,31 +6145,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -6819,6 +6317,7 @@
       </EnumInfo>
       <EnumInfo>
         <Text>TYPE_INTERFACE</Text>
+        <Enum>-4096</Enum>
       </EnumInfo>
       <Properties>
         <Property>
@@ -7088,16 +6587,6 @@
         <BitOffs>24640416</BitOffs>
       </SubItem>
       <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>CopyDetectionCountAndResetDetectionCountInThisCycle</Name>
         <Local>
           <Name>IteratorCounter</Name>
@@ -7124,21 +6613,6 @@
           <Type>UINT</Type>
           <BitSize>16</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>CreateAssertResultInstance</Name>
@@ -7601,31 +7075,6 @@
         <BitOffs>8480416</BitOffs>
       </SubItem>
       <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>CreateAssertResultInstance</Name>
         <Parameter>
           <Name>ExpectedsSize</Name>
@@ -8049,31 +7498,6 @@
           <Value>253</Value>
         </Default>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -8090,31 +7514,6 @@
 </Comment>
       <BitSize>128</BitSize>
       <Implements Namespace="TcUnit">I_AssertMessageFormatter</Implements>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Method>
         <Name>LogAssertFailure</Name>
         <Parameter>
@@ -8533,21 +7932,6 @@
           <Type>BOOL</Type>
           <BitSize>8</BitSize>
         </Local>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>GetNumberOfFailedTests</Name>
@@ -11258,16 +10642,6 @@
         </Local>
       </Method>
       <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>AssertArray2dEquals_REAL</Name>
         <Comment>
     Asserts that two REAL 2D-arrays are equal to within a positive delta. If they are not, an assertion error is created.
@@ -12283,31 +11657,6 @@
       <Action>
         <Name>A_GetHead</Name>
       </Action>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -12385,31 +11734,6 @@
         <BitSize>32</BitSize>
         <BitOffs>224</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -12448,11 +11772,11 @@
         <Default>
           <SubItem>
             <Name>.IN</Name>
-            <Value>1</Value>
+            <Bool>true</Bool>
           </SubItem>
           <SubItem>
             <Name>.PT</Name>
-            <Value>10</Value>
+            <DateTime>T#10MS</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -12471,19 +11795,9 @@
         <BitSize>32</BitSize>
         <BitOffs>8321120</BitOffs>
         <Default>
-          <Value>10</Value>
+          <DateTime>T#10MS</DateTime>
         </Default>
       </SubItem>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Method>
         <Name>GetLogCount</Name>
         <ReturnType>UDINT</ReturnType>
@@ -12550,21 +11864,6 @@
               <Value>Output</Value>
             </Property>
           </Properties>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
         </Parameter>
       </Method>
       <Properties>
@@ -12650,7 +11949,7 @@
         <BitSize>8</BitSize>
         <BitOffs>6160</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
         <Properties>
           <Property>
@@ -12676,7 +11975,7 @@
         <BitSize>8</BitSize>
         <BitOffs>6176</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -12760,31 +12059,6 @@
         <BitSize>32</BitSize>
         <BitOffs>192</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -12992,31 +12266,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13151,9 +12400,9 @@
     </DataType>
     <DataType>
       <Name Namespace="Tc2_Utilities">E_TimeZoneID</Name>
+      <Comment> Time zone identifier </Comment>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
-      <Comment> Time zone identifier </Comment>
       <EnumInfo>
         <Text>eTimeZoneID_Invalid</Text>
         <Enum>-1</Enum>
@@ -13286,7 +12535,7 @@
         <BitSize>32</BitSize>
         <BitOffs>480</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -13334,31 +12583,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13406,7 +12630,7 @@
         <BitSize>32</BitSize>
         <BitOffs>288</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -13489,31 +12713,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13584,7 +12783,7 @@
         <BitSize>32</BitSize>
         <BitOffs>288</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -13711,31 +12910,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -13851,7 +13025,7 @@
         <BitSize>32</BitSize>
         <BitOffs>480</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -13899,31 +13073,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -14068,7 +13217,7 @@
         <BitSize>32</BitSize>
         <BitOffs>608</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -14129,31 +13278,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -14274,7 +13398,7 @@
         <BitSize>32</BitSize>
         <BitOffs>4512</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -14434,31 +13558,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -14505,7 +13604,7 @@
         <BitSize>32</BitSize>
         <BitOffs>288</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -14641,7 +13740,7 @@
         <BitSize>8</BitSize>
         <BitOffs>12840</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -14663,31 +13762,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -14725,31 +13799,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -14804,31 +13853,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -15038,31 +14062,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -15145,7 +14144,7 @@
         <BitSize>32</BitSize>
         <BitOffs>352</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -15187,7 +14186,7 @@
         <BitSize>16</BitSize>
         <BitOffs>528</BitOffs>
         <Default>
-          <Value>-1</Value>
+          <EnumText>E_TimeZoneID.eTimeZoneID_Invalid</EnumText>
         </Default>
         <Properties>
           <Property>
@@ -15295,31 +14294,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -15431,7 +14405,7 @@
         <BitSize>16</BitSize>
         <BitOffs>1088</BitOffs>
         <Default>
-          <Value>0</Value>
+          <EnumText>E_TimeZoneID.eTimeZoneID_Unknown</EnumText>
         </Default>
         <Properties>
           <Property>
@@ -15601,31 +14575,6 @@
       <Action>
         <Name>A_Reset</Name>
       </Action>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -15686,7 +14635,7 @@
         <BitSize>16</BitSize>
         <BitOffs>1184</BitOffs>
         <Default>
-          <Value>0</Value>
+          <EnumText>E_TimeZoneID.eTimeZoneID_Unknown</EnumText>
         </Default>
         <Properties>
           <Property>
@@ -15722,31 +14671,6 @@
       <Action>
         <Name>A_Reset</Name>
       </Action>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -15773,7 +14697,7 @@
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
         <Default>
-          <Value>-1743714536</Value>
+          <EnumText>E_HRESULTAdsErr.NOTINIT</EnumText>
         </Default>
         <Properties>
           <Property>
@@ -15955,21 +14879,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>ResetDocument</Name>
         <Comment> | Resets the internal JSON document if a new document should be created with the same SaxWriter instance.</Comment>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
@@ -15998,16 +14907,6 @@
         <Name>StartObject</Name>
         <ReturnType GUID="{18071995-0000-0000-0000-000000000019}">HRESULT</ReturnType>
         <ReturnBitSize>32</ReturnBitSize>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>GetDocumentLength</Name>
@@ -16415,7 +15314,7 @@
         <BitSize>8</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
         <Properties>
           <Property>
@@ -16502,7 +15401,7 @@
         <BitSize>8</BitSize>
         <BitOffs>406720</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
         <Properties>
           <Property>
@@ -16541,7 +15440,7 @@
         <BitSize>8</BitSize>
         <BitOffs>408960</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -16589,7 +15488,7 @@
         <Default>
           <SubItem>
             <Name>.bEnable</Name>
-            <Value>1</Value>
+            <Bool>true</Bool>
           </SubItem>
           <SubItem>
             <Name>.dwCycle</Name>
@@ -16633,11 +15532,11 @@
         <Default>
           <SubItem>
             <Name>.eSevr</Name>
-            <Value>4</Value>
+            <EnumText>TcEventSeverity.Critical</EnumText>
           </SubItem>
           <SubItem>
             <Name>.eSubsystem</Name>
-            <Value>2</Value>
+            <EnumText>E_Subsystem.MPS</EnumText>
           </SubItem>
           <SubItem>
             <Name>.nMinTimeViolationAcceptable</Name>
@@ -16653,7 +15552,7 @@
         <Default>
           <SubItem>
             <Name>.PT</Name>
-            <Value>86400000</Value>
+            <DateTime>86400000</DateTime>
           </SubItem>
         </Default>
       </SubItem>
@@ -16733,31 +15632,6 @@
             <Name>no_check</Name>
           </Property>
         </Properties>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
       </Method>
       <Method>
         <Name>Register</Name>
@@ -16902,7 +15776,7 @@
         <BitSize>32</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -17060,31 +15934,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -17922,21 +16771,6 @@
         <Parameter>
           <Name>value</Name>
           <Type GUID="{18071995-0000-0000-0000-000000000047}">DCTIME</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
           <BitSize>64</BitSize>
         </Parameter>
       </Method>
@@ -18791,16 +17625,6 @@
         </Parameter>
       </Method>
       <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
         <Name>GetBool</Name>
         <ReturnType>BOOL</ReturnType>
         <ReturnBitSize>8</ReturnBitSize>
@@ -19051,7 +17875,7 @@
         <BitSize>32</BitSize>
         <BitOffs>256</BitOffs>
         <Default>
-          <Value>-1743714536</Value>
+          <EnumText>E_HRESULTAdsErr.NOTINIT</EnumText>
         </Default>
         <Properties>
           <Property>
@@ -19117,31 +17941,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -19158,9 +17957,9 @@
     </DataType>
     <DataType>
       <Name Namespace="Tc2_System">E_OpenPath</Name>
+      <Comment> File open path </Comment>
       <BitSize>16</BitSize>
       <BaseType>UINT</BaseType>
-      <Comment> File open path </Comment>
       <EnumInfo>
         <Text>PATH_GENERIC</Text>
         <Enum>1</Enum>
@@ -19277,7 +18076,7 @@
         <BitSize>16</BitSize>
         <BitOffs>2336</BitOffs>
         <Default>
-          <Value>1</Value>
+          <EnumText>E_OpenPath.PATH_GENERIC</EnumText>
         </Default>
         <Properties>
           <Property>
@@ -19306,7 +18105,7 @@
         <BitSize>32</BitSize>
         <BitOffs>2368</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -19367,31 +18166,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -19452,7 +18226,7 @@
         <BitSize>32</BitSize>
         <BitOffs>288</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -19500,31 +18274,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -19614,7 +18363,7 @@
         <BitSize>32</BitSize>
         <BitOffs>448</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -19688,31 +18437,6 @@
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -19769,7 +18493,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>8</BitSize>
         <BitOffs>80</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
         <Properties>
           <Property>
@@ -19785,7 +18509,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>8</BitSize>
         <BitOffs>88</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -19901,7 +18625,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>8</BitSize>
         <BitOffs>13184</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -19922,31 +18646,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>2048</BitSize>
         <BitOffs>23872</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -20203,7 +18902,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>823424</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -20227,7 +18926,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.eSubsystem</Name>
-            <Value>2</Value>
+            <EnumText>E_Subsystem.MPS</EnumText>
           </SubItem>
           <SubItem>
             <Name>.nMinTimeViolationAcceptable</Name>
@@ -20258,31 +18957,6 @@ contributing fast faults, unless the FFO is currently vetoed.
       <Action>
         <Name>ACT_Logger</Name>
       </Action>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -20296,6 +18970,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       <SubItem>
         <Name>io_fbFFHWO</Name>
         <Type Namespace="PMPS" ReferenceTo="true">FB_HardwareFFOutput</Type>
+        <Comment> The fast fault output to fault to.</Comment>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -20431,7 +19106,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <Default>
           <SubItem>
             <Name>.bEnable</Name>
-            <Value>1</Value>
+            <Bool>true</Bool>
           </SubItem>
           <SubItem>
             <Name>.dwCycle</Name>
@@ -20451,31 +19126,6 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>3776</BitSize>
         <BitOffs>26368</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -20838,31 +19488,6 @@ contributing fast faults, unless the FFO is currently vetoed.
  Workaround for compile defines not fully working for libraries at the time of writing this.
  Otherwise I would have just used the compile define in the GVL declaration.</Comment>
       <BitSize>64</BitSize>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -22462,7 +21087,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>288</BitOffs>
         <Default>
-          <Value>5000</Value>
+          <DateTime>5000</DateTime>
         </Default>
         <Properties>
           <Property>
@@ -22536,31 +21161,6 @@ contributing fast faults, unless the FFO is currently vetoed.
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -22810,7 +21410,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>5536</BitOffs>
         <Default>
-          <Value>6000</Value>
+          <DateTime>6000</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -22819,7 +21419,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>5568</BitOffs>
         <Default>
-          <Value>1000</Value>
+          <DateTime>1000</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -22828,7 +21428,7 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>32</BitSize>
         <BitOffs>5600</BitOffs>
         <Default>
-          <Value>100</Value>
+          <DateTime>100</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -22861,31 +21461,6 @@ contributing fast faults, unless the FFO is currently vetoed.
       <Action>
         <Name>ReadDeviceInfo</Name>
       </Action>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -22952,7 +21527,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Format>
     </DataType>
     <DataType>
-      <Name GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF</Name>
+      <Name GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}" Namespace="MC" TcBaseType="true">PLCTONC_AXIS_REF</Name>
       <BitSize>1024</BitSize>
       <SubItem>
         <Name>ControlDWord</Name>
@@ -23062,6 +21637,12 @@ contributing fast faults, unless the FFO is currently vetoed.
         <BitSize>8</BitSize>
         <BitOffs>848</BitOffs>
       </SubItem>
+      <SubItem>
+        <Name>ExtTorque</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>896</BitOffs>
+      </SubItem>
       <Properties>
         <Property>
           <Name>NcStructType</Name>
@@ -23070,7 +21651,10 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Properties>
       <Relations>
         <Relation Priority="100">
-          <Type GUID="{60392271-8688-4F4C-B404-618DF106325D}">NCAXLESTRUCT_FROMPLC3</Type>
+          <Type GUID="{60392271-8688-4F4C-B404-618DF106325D}"/>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}"/>
         </Relation>
       </Relations>
     </DataType>
@@ -23435,6 +22019,56 @@ contributing fast faults, unless the FFO is currently vetoed.
       </Format>
     </DataType>
     <DataType>
+      <Name GUID="{F7B9FC50-054E-4547-B468-83A9E72D8064}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE3_FLAGS</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>TouchProbe1InputState </Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>TouchProbe2InputState </Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000010}">BIT</Type>
+        <BitSize>1</BitSize>
+        <BitOffs>1</BitOffs>
+      </SubItem>
+      <Format Name="Short">
+        <Printf>%08x</Printf>
+      </Format>
+      <Format Name="Cpp">
+        <Printf>0x%08x</Printf>
+      </Format>
+      <Format Name="IEC">
+        <Printf>16#%08X</Printf>
+      </Format>
+    </DataType>
+    <DataType>
+      <Name GUID="{60E203BA-3CEE-4BB0-8728-643B1F529592}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_STATE3</Name>
+      <BitSize>32</BitSize>
+      <SubItem>
+        <Name>Value</Name>
+        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <SubItem>
+        <Name>Flags</Name>
+        <Type GUID="{F7B9FC50-054E-4547-B468-83A9E72D8064}" Namespace="MC">NCTOPLC_AXIS_REF_STATE3_FLAGS</Type>
+        <BitSize>32</BitSize>
+        <BitOffs>0</BitOffs>
+      </SubItem>
+      <Format Name="Short">
+        <Printf>%08x</Printf>
+      </Format>
+      <Format Name="Cpp">
+        <Printf>0x%08x</Printf>
+      </Format>
+      <Format Name="IEC">
+        <Printf>16#%08X</Printf>
+      </Format>
+    </DataType>
+    <DataType>
       <Name GUID="{BA9D9D0F-1A4A-4A27-A19F-3032626A8491}" Namespace="MC" TcBaseType="true" HideType="true">NCTOPLC_AXIS_REF_CAMCOUPLINGSTATE</Name>
       <BitSize>8</BitSize>
       <SubItem>
@@ -23478,7 +22112,7 @@ contributing fast faults, unless the FFO is currently vetoed.
       </ArrayInfo>
     </DataType>
     <DataType>
-      <Name GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
+      <Name GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}" Namespace="MC" TcBaseType="true">NCTOPLC_AXIS_REF</Name>
       <BitSize>2048</BitSize>
       <SubItem>
         <Name>StateDWord</Name>
@@ -23566,7 +22200,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>OpModeDWord</Name>
-        <Type GUID="{6EF49753-C72C-4F50-AA44-3C7498E76CFE}" Namespace="MC">NCTOPLC_AXIS_REF_OPMODE</Type>
+        <Type GUID="{6BDEED54-7268-405F-A18B-665A0AE0FEE9}" Namespace="MC">NCTOPLC_AXIS_REF_OPMODE</Type>
         <BitSize>32</BitSize>
         <BitOffs>288</BitOffs>
       </SubItem>
@@ -23686,7 +22320,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>StateDWord3</Name>
-        <Type GUID="{18071995-0000-0000-0000-000000000007}">DWORD</Type>
+        <Type GUID="{60E203BA-3CEE-4BB0-8728-643B1F529592}" Namespace="MC">NCTOPLC_AXIS_REF_STATE3</Type>
         <BitSize>32</BitSize>
         <BitOffs>1248</BitOffs>
       </SubItem>
@@ -23760,6 +22394,12 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>1920</BitOffs>
       </SubItem>
+      <SubItem>
+        <Name>UserData</Name>
+        <Type GUID="{18071995-0000-0000-0000-00000000000E}">LREAL</Type>
+        <BitSize>64</BitSize>
+        <BitOffs>1984</BitOffs>
+      </SubItem>
       <Properties>
         <Property>
           <Name>NcStructType</Name>
@@ -23791,6 +22431,12 @@ External Setpoint Generation:
         <Relation Priority="100">
           <Type GUID="{6A65C767-34E5-42BF-AD87-E1A503EAC7BE}"/>
         </Relation>
+        <Relation Priority="100">
+          <Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}"/>
+        </Relation>
+        <Relation Priority="100">
+          <Type GUID="{10036166-C9D3-404B-BDD3-323034AAA7F4}"/>
+        </Relation>
       </Relations>
     </DataType>
     <DataType>
@@ -23817,11 +22463,11 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">MC_AxisStates</Name>
-      <BitSize>16</BitSize>
-      <BaseType>INT</BaseType>
       <Comment> 	PLCopen axis states
 	The axis states are defined in the PLCopen state diagram
 </Comment>
+      <BitSize>16</BitSize>
+      <BaseType>INT</BaseType>
       <EnumInfo>
         <Text>MC_AXISSTATE_UNDEFINED</Text>
         <Enum>0</Enum>
@@ -24765,9 +23411,9 @@ External Setpoint Generation:
     </DataType>
     <DataType>
       <Name Namespace="Tc2_MC2">_E_PhasingState</Name>
+      <Comment> Phasing internal probe states </Comment>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
-      <Comment> Phasing internal probe states </Comment>
       <EnumInfo>
         <Text>PhasingInactive</Text>
         <Enum>0</Enum>
@@ -24845,7 +23491,7 @@ External Setpoint Generation:
       <BitSize>9088</BitSize>
       <SubItem>
         <Name>PlcToNc</Name>
-        <Type GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</Type>
+        <Type GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</Type>
         <BitSize>1024</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -24861,7 +23507,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>NcToPlc</Name>
-        <Type GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</Type>
+        <Type GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</Type>
         <BitSize>2048</BitSize>
         <BitOffs>1088</BitOffs>
         <Properties>
@@ -24940,31 +23586,6 @@ External Setpoint Generation:
       <Action>
         <Name>ReadStatus</Name>
       </Action>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -25039,12 +23660,22 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>1328</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
+        <Properties>
+          <Property>
+            <Name>pytmc</Name>
+            <Value>
+        pv: bEPS_OK
+        io: i
+        field: DESC check if nFlags are all true
+    </Value>
+          </Property>
+        </Properties>
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_StageEnableMode</Name>
+      <Name Namespace="lcls_twincat_motion">E_StageEnableMode</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -25072,7 +23703,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_StageBrakeMode</Name>
+      <Name Namespace="lcls_twincat_motion">E_StageBrakeMode</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -25100,7 +23731,7 @@ External Setpoint Generation:
       </Properties>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">ENUM_EpicsHomeCmd</Name>
+      <Name Namespace="lcls_twincat_motion">E_EpicsHomeCmd</Name>
       <BitSize>16</BitSize>
       <BaseType>INT</BaseType>
       <EnumInfo>
@@ -25852,7 +24483,7 @@ External Setpoint Generation:
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">DUT_MotionStage</Name>
+      <Name Namespace="lcls_twincat_motion">ST_MotionStage</Name>
       <BitSize>25280</BitSize>
       <SubItem>
         <Name>Axis</Name>
@@ -25870,16 +24501,6 @@ External Setpoint Generation:
         <BitOffs>9088</BitOffs>
         <Properties>
           <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-          </Property>
-          <Property>
             <Name>TcAddressType</Name>
             <Value>Input</Value>
           </Property>
@@ -25892,16 +24513,6 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>9096</BitOffs>
         <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-          </Property>
           <Property>
             <Name>TcAddressType</Name>
             <Value>Input</Value>
@@ -25916,16 +24527,6 @@ External Setpoint Generation:
         <BitOffs>9104</BitOffs>
         <Properties>
           <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-          </Property>
-          <Property>
             <Name>TcAddressType</Name>
             <Value>Input</Value>
           </Property>
@@ -25938,16 +24539,6 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>9112</BitOffs>
         <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-          </Property>
           <Property>
             <Name>TcAddressType</Name>
             <Value>Output</Value>
@@ -26024,20 +24615,8 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>9248</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bAllForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to move forward
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bAllBackwardEnable</Name>
@@ -26046,20 +24625,8 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>9256</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bAllBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to move backward
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bAllEnable</Name>
@@ -26068,20 +24635,8 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>9264</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bAllEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Summary of axis permission to have power
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bGantryForwardEnable</Name>
@@ -26090,20 +24645,8 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>9272</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bGantryForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry ok to move forward
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bGantryBackwardEnable</Name>
@@ -26112,20 +24655,8 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>9280</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bGantryBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry ok to move backward
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nEncoderCount</Name>
@@ -26154,7 +24685,7 @@ External Setpoint Generation:
           <Property>
             <Name>pytmc</Name>
             <Value>
-        pv: PLC:stEPSForwardEnable
+        pv: PLC:stEPSF
         io: i
         field: DESC Forward Enable Interlocks
     </Value>
@@ -26171,7 +24702,7 @@ External Setpoint Generation:
           <Property>
             <Name>pytmc</Name>
             <Value>
-        pv: PLC:stEPSBackwardEnable
+        pv: PLC:stEPSB
         io: i
         field: DESC Backward Enable Interlocks
     </Value>
@@ -26188,7 +24719,7 @@ External Setpoint Generation:
           <Property>
             <Name>pytmc</Name>
             <Value>
-        pv: PLC:stEPSPowerEnable
+        pv: PLC:stEPSP
         io: i
         field: DESC Power Interlocks
     </Value>
@@ -26202,16 +24733,6 @@ External Setpoint Generation:
  Name to use for log messages, fast faults, etc.</Comment>
         <BitSize>648</BitSize>
         <BitOffs>13376</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:sName
-        io: i
-        field: DESC PLC program name
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bPowerSelf</Name>
@@ -26220,80 +24741,38 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>14024</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bPowerSelf
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if axis is in PMPS
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nEnableMode</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_StageEnableMode</Type>
+        <Type Namespace="lcls_twincat_motion">E_StageEnableMode</Type>
         <Comment> Determines when we automatically enable the motor</Comment>
         <BitSize>16</BitSize>
         <BitOffs>14032</BitOffs>
         <Default>
-          <Value>2</Value>
+          <EnumText>E_StageEnableMode.DURING_MOTION</EnumText>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nEnableMode
-        io: i
-        field: DESC Describes when the axis will automatically get power
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nBrakeMode</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_StageBrakeMode</Type>
+        <Type Namespace="lcls_twincat_motion">E_StageBrakeMode</Type>
         <Comment> Determines when we automatically disengage the brake</Comment>
         <BitSize>16</BitSize>
         <BitOffs>14048</BitOffs>
         <Default>
-          <Value>0</Value>
+          <EnumText>E_StageBrakeMode.IF_ENABLED</EnumText>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nBrakeMode
-        io: i
-        field: DESC Describes when the brake will be released
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nHomingMode</Name>
-        <Type Namespace="lcls_twincat_motion">ENUM_EpicsHomeCmd</Type>
+        <Type Namespace="lcls_twincat_motion">E_EpicsHomeCmd</Type>
         <Comment> Determines our encoder homing strategy</Comment>
         <BitSize>16</BitSize>
         <BitOffs>14064</BitOffs>
         <Default>
-          <Value>-1</Value>
+          <EnumText>E_EpicsHomeCmd.NONE</EnumText>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nHomingMode
-        io: i
-        field: DESC Describes our homing strategy
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bGantryAxis</Name>
@@ -26302,20 +24781,8 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>14080</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bGantryAxis
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if gantry EPS active
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nGantryTol</Name>
@@ -26344,18 +24811,6 @@ External Setpoint Generation:
  Used internally to request enables</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14272</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bEnable
-        io: io
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Used internally to request enables
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bReset</Name>
@@ -26382,18 +24837,6 @@ External Setpoint Generation:
         <Comment> Used internally and by the IOC to start or stop a move</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14288</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bExecute
-        io: io
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC Used internally and by the IOC to start or stop
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bUserEnable</Name>
@@ -26402,7 +24845,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>14296</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>1</Bool>
         </Default>
         <Properties>
           <Property>
@@ -26424,16 +24867,6 @@ External Setpoint Generation:
  Start a move to fPosition with fVelocity</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14304</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bMoveCmd
-        io: io
-        field: DESC Start a move
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bHomeCmd</Name>
@@ -26459,16 +24892,6 @@ External Setpoint Generation:
  Used internally and by the IOC to pick what kind of move to do</Comment>
         <BitSize>16</BitSize>
         <BitOffs>14320</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nCommand
-        io: io
-        field: DESC Used internally and by the IOC to pick move type
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>nCmdData</Name>
@@ -26476,16 +24899,6 @@ External Setpoint Generation:
         <Comment> Used internally and by the IOC to pass additional data to some commands</Comment>
         <BitSize>16</BitSize>
         <BitOffs>14336</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nCmdData
-        io: io
-        field: DESC Used internally and by the IOC to pass extra args
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fPosition</Name>
@@ -26493,16 +24906,6 @@ External Setpoint Generation:
         <Comment> Used internally and by the IOC to pick a destination for the move</Comment>
         <BitSize>64</BitSize>
         <BitOffs>14400</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fPosition
-        io: io
-        field: DESC Used internally and by the IOC as the set position
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fVelocity</Name>
@@ -26510,16 +24913,6 @@ External Setpoint Generation:
         <Comment> Used internally and by the IOC to pick a move velocity</Comment>
         <BitSize>64</BitSize>
         <BitOffs>14464</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fVelocity
-        io: io
-        field: DESC Used internally and by the IOC to set velocity
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fAcceleration</Name>
@@ -26527,16 +24920,6 @@ External Setpoint Generation:
         <Comment> Used internally and by the IOC to pick a move acceleration</Comment>
         <BitSize>64</BitSize>
         <BitOffs>14528</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fAcceleration
-        io: io
-        field: DESC Used internally and by the IOC to set acceleration
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fDeceleration</Name>
@@ -26544,16 +24927,6 @@ External Setpoint Generation:
         <Comment> Used internally and by the IOC to pick a move deceleration</Comment>
         <BitSize>64</BitSize>
         <BitOffs>14592</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:fDeceleration
-        io: io
-        field: DESC Used internally and by the IOC to set deceleration
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>fHomePosition</Name>
@@ -26582,16 +24955,6 @@ External Setpoint Generation:
         <Default>
           <Value>0</Value>
         </Default>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:nMotionAxisID
-        io: i
-        field: DESC Unique ID assigned to each axis in the NC
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bEnableDone</Name>
@@ -26600,18 +24963,6 @@ External Setpoint Generation:
  TRUE if done enabling</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14752</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bEnableDone
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if done enabling
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bBusy</Name>
@@ -26619,18 +24970,6 @@ External Setpoint Generation:
         <Comment> TRUE if in the middle of a command</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14760</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bBusy
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if in the middle of a command
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bDone</Name>
@@ -26638,18 +24977,6 @@ External Setpoint Generation:
         <Comment> TRUE if we've done a command and it has finished</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14768</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bDone
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if command finished successfully
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bHomed</Name>
@@ -26657,16 +24984,6 @@ External Setpoint Generation:
         <Comment> TRUE if the motor has been homed, or does not need to be homed</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14776</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bHomed
-        io: i
-        field: DESC TRUE if the motor has been homed
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bSafetyReady</Name>
@@ -26674,18 +24991,6 @@ External Setpoint Generation:
         <Comment> TRUE if we have safety permission to move</Comment>
         <BitSize>8</BitSize>
         <BitOffs>14784</BitOffs>
-        <Properties>
-          <Property>
-            <Name>pytmc</Name>
-            <Value>
-        pv: PLC:bSafetyReady
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if safe to start a move
-    </Value>
-          </Property>
-        </Properties>
       </SubItem>
       <SubItem>
         <Name>bError</Name>
@@ -26791,7 +25096,18 @@ External Setpoint Generation:
       </SubItem>
     </DataType>
     <DataType>
-      <Name Namespace="lcls_twincat_motion">EL5042_Status</Name>
+      <Name Namespace="lcls_twincat_motion">DUT_MotionStage</Name>
+      <BitSize>25280</BitSize>
+      <BaseType Namespace="lcls_twincat_motion">ST_MotionStage</BaseType>
+      <Properties>
+        <Property>
+          <Name>obsolete</Name>
+          <Value>DUT_MotionStage has been renamed to ST_MotionStage</Value>
+        </Property>
+      </Properties>
+    </DataType>
+    <DataType>
+      <Name Namespace="lcls_twincat_motion">ST_EL5042_Status</Name>
       <BitSize>0</BitSize>
     </DataType>
     <DataType>
@@ -26813,7 +25129,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>Status</Name>
-        <Type Namespace="lcls_twincat_motion">EL5042_Status</Type>
+        <Type Namespace="lcls_twincat_motion">ST_EL5042_Status</Type>
         <Comment> Status struct placeholder</Comment>
         <BitSize>0</BitSize>
         <BitOffs>64</BitOffs>
@@ -26926,31 +25242,6 @@ External Setpoint Generation:
         <BitSize>64</BitSize>
         <BitOffs>448</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -27450,7 +25741,7 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>720</BitOffs>
         <Default>
-          <Value>100</Value>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -27517,31 +25808,6 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -27778,7 +26044,7 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>816</BitOffs>
         <Default>
-          <Value>100</Value>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -27827,31 +26093,6 @@ External Setpoint Generation:
       <Action>
         <Name>WriteGearRatio</Name>
       </Action>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -27985,7 +26226,7 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>336</BitOffs>
         <Default>
-          <Value>100</Value>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -28016,31 +26257,6 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -28053,7 +26269,7 @@ External Setpoint Generation:
       <BitSize>128</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -28063,31 +26279,6 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -28124,7 +26315,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>Master</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>192</BitOffs>
         <Properties>
@@ -28148,7 +26339,7 @@ External Setpoint Generation:
       </SubItem>
       <SubItem>
         <Name>Slave</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>320</BitOffs>
         <Properties>
@@ -28224,31 +26415,6 @@ External Setpoint Generation:
         <BitSize>128</BitSize>
         <BitOffs>10624</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -28587,31 +26753,6 @@ External Setpoint Generation:
         <BitSize>10752</BitSize>
         <BitOffs>12544</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -28639,9 +26780,9 @@ External Setpoint Generation:
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: COUPLE_Y
-		io: o
-	</Value>
+        pv: COUPLE_Y
+        io: o
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -28654,9 +26795,9 @@ External Setpoint Generation:
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: DECOUPLE_Y
-		io: o
-	</Value>
+        pv: DECOUPLE_Y
+        io: o
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -28669,9 +26810,9 @@ External Setpoint Generation:
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: COUPLE_X
-		io: o
-	</Value>
+        pv: COUPLE_X
+        io: o
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -28684,9 +26825,9 @@ External Setpoint Generation:
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: DECOUPLE_X
-		io: o
-	</Value>
+        pv: DECOUPLE_X
+        io: o
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -28700,10 +26841,10 @@ External Setpoint Generation:
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: ALREADY_COUPLED_Y
-		io: i
+        pv: ALREADY_COUPLED_Y
+        io: i
         field: ZSV MAJOR
-	</Value>
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -28716,10 +26857,10 @@ External Setpoint Generation:
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: ALREADY_COUPLED_X
-		io: i
+        pv: ALREADY_COUPLED_X
+        io: i
         field: ZSV MAJOR
-	</Value>
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -28747,10 +26888,10 @@ External Setpoint Generation:
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: GANTRY_Y
-		field: EGU um
-		io: i
-	</Value>
+        pv: GANTRY_Y
+        field: EGU um
+        io: i
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -28764,10 +26905,10 @@ External Setpoint Generation:
           <Property>
             <Name>pytmc</Name>
             <Value>
-		pv: GANTRY_X
-		field: EGU um
-		io: i
-	</Value>
+        pv: GANTRY_X
+        field: EGU um
+        io: i
+    </Value>
           </Property>
         </Properties>
       </SubItem>
@@ -28811,31 +26952,6 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -28940,7 +27056,7 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>208</BitOffs>
         <Default>
-          <Value>100</Value>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -28960,31 +27076,6 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -29194,31 +27285,6 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -30036,7 +28102,7 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>1472</BitOffs>
         <Default>
-          <Value>100</Value>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -30267,31 +28333,6 @@ External Setpoint Generation:
       <Action>
         <Name>ActNcCycleCounter</Name>
       </Action>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -30479,31 +28520,6 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>9472</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -30650,7 +28666,7 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>448</BitOffs>
         <Default>
-          <Value>1</Value>
+          <EnumText>MC_Direction.MC_Positive_Direction</EnumText>
         </Default>
         <Properties>
           <Property>
@@ -30784,31 +28800,6 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>9600</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31083,31 +29074,6 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>9664</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31329,31 +29295,6 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>9664</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31699,31 +29640,6 @@ External Setpoint Generation:
       <Action>
         <Name>ActCheckJogEnd</Name>
       </Action>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -31972,31 +29888,6 @@ External Setpoint Generation:
       <Action>
         <Name>MC_MoveModuloCall</Name>
       </Action>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -32111,7 +30002,7 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>16</BitOffs>
         <Default>
-          <Value>128</Value>
+          <EnumText>MC_Direction.MC_Undefined_Direction</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -32126,7 +30017,7 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>128</BitOffs>
         <Default>
-          <Value>128</Value>
+          <EnumText>MC_Direction.MC_Undefined_Direction</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -32141,7 +30032,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>256</BitOffs>
         <Default>
-          <Value>0</Value>
+          <EnumText>E_EncoderReferenceMode.ENCODERREFERENCEMODE_DEFAULT</EnumText>
         </Default>
       </SubItem>
     </DataType>
@@ -32359,7 +30250,7 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>704</BitOffs>
         <Default>
-          <Value>100</Value>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -32379,31 +30270,6 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -32608,7 +30474,7 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>848</BitOffs>
         <Default>
-          <Value>100</Value>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
         </Default>
         <Properties>
           <Property>
@@ -32770,31 +30636,6 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -32929,31 +30770,6 @@ External Setpoint Generation:
         <BitSize>1344</BitSize>
         <BitOffs>384</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33085,31 +30901,6 @@ External Setpoint Generation:
         <BitSize>1344</BitSize>
         <BitOffs>448</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33270,31 +31061,6 @@ External Setpoint Generation:
         <BitSize>1792</BitSize>
         <BitOffs>2304</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33535,7 +31301,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>17856</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -33544,31 +31310,6 @@ External Setpoint Generation:
         <BitSize>128</BitSize>
         <BitOffs>17920</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33717,31 +31458,6 @@ External Setpoint Generation:
         <BitSize>8064</BitSize>
         <BitOffs>384</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -33873,31 +31589,6 @@ External Setpoint Generation:
         <BitSize>1408</BitSize>
         <BitOffs>384</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -34022,7 +31713,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>256</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -34037,7 +31728,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>264</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -34058,31 +31749,6 @@ External Setpoint Generation:
         <BitSize>1792</BitSize>
         <BitOffs>2112</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -34135,7 +31801,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>88</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -34150,7 +31816,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>96</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -34249,31 +31915,6 @@ External Setpoint Generation:
         <BitSize>1728</BitSize>
         <BitOffs>2112</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -34405,31 +32046,6 @@ External Setpoint Generation:
         <BitSize>1408</BitSize>
         <BitOffs>448</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -34584,31 +32200,6 @@ External Setpoint Generation:
         <BitSize>1856</BitSize>
         <BitOffs>2240</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -34745,7 +32336,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>256</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -34760,7 +32351,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>264</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -34836,7 +32427,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>20480</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -34845,7 +32436,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>20488</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -34857,31 +32448,6 @@ External Setpoint Generation:
           <Value>0</Value>
         </Default>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -34946,7 +32512,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>112</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -34961,7 +32527,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>120</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
         <Properties>
           <Property>
@@ -35060,7 +32626,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>4224</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -35072,31 +32638,6 @@ External Setpoint Generation:
           <Value>0</Value>
         </Default>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -35351,7 +32892,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>61648</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -35360,7 +32901,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>61656</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -35369,7 +32910,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>61664</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -35378,7 +32919,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>61672</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -35400,7 +32941,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>61712</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -35409,34 +32950,9 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>61720</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -35898,7 +33414,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>12384</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -35979,31 +33495,6 @@ External Setpoint Generation:
         <BitSize>768</BitSize>
         <BitOffs>181056</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -36016,7 +33507,7 @@ External Setpoint Generation:
       <BitSize>51904</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -36259,31 +33750,6 @@ External Setpoint Generation:
           <Value>99999999</Value>
         </Default>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -36296,7 +33762,7 @@ External Setpoint Generation:
       <BitSize>3264</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -36360,7 +33826,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>2784</BitOffs>
         <Default>
-          <Value>1000</Value>
+          <DateTime>T#1s</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -36415,31 +33881,6 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -36452,7 +33893,7 @@ External Setpoint Generation:
       <BitSize>87488</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -36504,31 +33945,6 @@ External Setpoint Generation:
         <BitSize>384</BitSize>
         <BitOffs>87104</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -36541,7 +33957,7 @@ External Setpoint Generation:
       <BitSize>128</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -36551,31 +33967,6 @@ External Setpoint Generation:
           </Property>
         </Properties>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -36687,7 +34078,7 @@ External Setpoint Generation:
         <BitSize>16</BitSize>
         <BitOffs>384</BitOffs>
         <Default>
-          <Value>100</Value>
+          <EnumText>_E_TcMC_STATES.STATE_INITIALIZATION</EnumText>
         </Default>
       </SubItem>
       <SubItem>
@@ -36711,31 +34102,6 @@ External Setpoint Generation:
       <Action>
         <Name>ActGetSizeOfParameterSet</Name>
       </Action>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -36748,7 +34114,7 @@ External Setpoint Generation:
       <BitSize>2560</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -36812,7 +34178,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>2496</BitOffs>
         <Default>
-          <Value>1</Value>
+          <Bool>true</Bool>
         </Default>
       </SubItem>
       <SubItem>
@@ -36821,31 +34187,6 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>2528</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -36858,7 +34199,7 @@ External Setpoint Generation:
       <BitSize>328512</BitSize>
       <SubItem>
         <Name>stMotionStage</Name>
-        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">DUT_MotionStage</Type>
+        <Type Namespace="lcls_twincat_motion" ReferenceTo="true">ST_MotionStage</Type>
         <BitSize>64</BitSize>
         <BitOffs>64</BitOffs>
         <Properties>
@@ -37012,31 +34353,6 @@ External Setpoint Generation:
         <BitSize>128</BitSize>
         <BitOffs>328384</BitOffs>
       </SubItem>
-      <Method>
-        <Name>__GetInterfacePointer</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
-      <Method>
-        <Name>__GetInterfaceReference</Name>
-        <ReturnType>BOOL</ReturnType>
-        <ReturnBitSize>8</ReturnBitSize>
-        <Parameter>
-          <Name>nInterfaceId</Name>
-          <Type>DINT</Type>
-          <BitSize>32</BitSize>
-        </Parameter>
-        <Parameter>
-          <Name>pRef</Name>
-          <Type PointerTo="2">DWORD</Type>
-          <BitSize>64</BitSize>
-        </Parameter>
-      </Method>
       <Properties>
         <Property>
           <Name>PouType</Name>
@@ -37054,7 +34370,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>0</BitOffs>
         <Default>
-          <Value>0</Value>
+          <DateTime>0</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -37064,7 +34380,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>32</BitOffs>
         <Default>
-          <Value>0</Value>
+          <DateTime>0</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -37074,7 +34390,7 @@ External Setpoint Generation:
         <BitSize>32</BitSize>
         <BitOffs>64</BitOffs>
         <Default>
-          <Value>0</Value>
+          <DateTime>0</DateTime>
         </Default>
       </SubItem>
       <SubItem>
@@ -37114,7 +34430,7 @@ External Setpoint Generation:
         <BitSize>8</BitSize>
         <BitOffs>320</BitOffs>
         <Default>
-          <Value>0</Value>
+          <Bool>false</Bool>
         </Default>
       </SubItem>
     </DataType>
@@ -37166,7 +34482,7 @@ External Setpoint Generation:
       <SubItem>
         <Name>sAxis</Name>
         <Type>STRING(80)</Type>
-        <Comment>Axis, e.g. A, B, C...A if single unit	</Comment>
+        <Comment>Axis, e.g. A, B, C...A if single unit</Comment>
         <BitSize>648</BitSize>
         <BitOffs>800</BitOffs>
         <Default>
@@ -37254,15 +34570,15 @@ External Setpoint Generation:
         <Default>
           <SubItem>
             <Name>.tCtrlCycleTime</Name>
-            <Value>0</Value>
+            <DateTime>T#0MS</DateTime>
           </SubItem>
           <SubItem>
             <Name>.tTaskCycleTime</Name>
-            <Value>0</Value>
+            <DateTime>T#0MS</DateTime>
           </SubItem>
           <SubItem>
             <Name>.tTn</Name>
-            <Value>200</Value>
+            <DateTime>T#200MS</DateTime>
           </SubItem>
           <SubItem>
             <Name>.fKp</Name>
@@ -37278,7 +34594,7 @@ External Setpoint Generation:
           </SubItem>
           <SubItem>
             <Name>.bARWOnIPartOnly</Name>
-            <Value>0</Value>
+            <Bool>false</Bool>
           </SubItem>
         </Default>
       </SubItem>
@@ -37332,8 +34648,8 @@ External Setpoint Generation:
         <Comment> Hard limits, egu INC 
  These are discovered during installation, and represent encoder ticks, unbiased 
  We changed to these when our pitch mechanism limit switches were insufficient for
-	good control. They had too much hysteresis/ lack of precision. At this point the limit
-	switches are ignored, and instead their function is carried out by these. </Comment>
+    good control. They had too much hysteresis/ lack of precision. At this point the limit
+    switches are ignored, and instead their function is carried out by these. </Comment>
         <BitSize>64</BitSize>
         <BitOffs>2304</BitOffs>
       </SubItem>
@@ -37893,9 +35209,335 @@ External Setpoint Generation:
         <Hide GUID="{9E76D1D7-D744-4E3D-B111-F6F94B60E6AB}"/>
       </Hides>
     </DataType>
+    <DataType>
+      <Name>ST_LCLSGeneralEventClass</Name>
+      <BitSize>960</BitSize>
+      <SubItem>
+        <Name>Critical</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>0</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>2546958919</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>46492</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>20012</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>180</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>176</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>115</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>80</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>208</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>71</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>20</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>87</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_LCLSGeneralEventClass.Critical</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Critical</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>Error</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>192</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>2546958919</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>46492</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>20012</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>180</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>176</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>115</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>80</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>208</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>71</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>20</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>87</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_LCLSGeneralEventClass.Error</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Error</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>Warning</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>384</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>2546958919</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>46492</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>20012</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>180</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>176</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>115</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>80</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>208</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>71</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>20</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>87</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_LCLSGeneralEventClass.Warning</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Warning</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>Info</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>576</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>2546958919</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>46492</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>20012</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>180</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>176</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>115</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>80</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>208</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>71</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>20</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>87</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_LCLSGeneralEventClass.Info</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Info</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <SubItem>
+        <Name>Verbose</Name>
+        <Type GUID="{F00C83AD-DEC8-486E-AE99-5E0A75C26DE0}">TcEventEntry</Type>
+        <BitSize>192</BitSize>
+        <BitOffs>768</BitOffs>
+        <Default>
+          <SubItem>
+            <Name>.uuidEventClass.Data1</Name>
+            <Value>2546958919</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data2</Name>
+            <Value>46492</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data3</Name>
+            <Value>20012</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[0]</Name>
+            <Value>180</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[1]</Name>
+            <Value>176</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[2]</Name>
+            <Value>115</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[3]</Name>
+            <Value>80</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[4]</Name>
+            <Value>208</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[5]</Name>
+            <Value>71</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[6]</Name>
+            <Value>20</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.uuidEventClass.Data4[7]</Name>
+            <Value>87</Value>
+          </SubItem>
+          <SubItem>
+            <Name>.nEventID</Name>
+            <EnumText>E_LCLSGeneralEventClass.Verbose</EnumText>
+          </SubItem>
+          <SubItem>
+            <Name>.eSeverity</Name>
+            <EnumText>TcEventSeverity.Verbose</EnumText>
+          </SubItem>
+        </Default>
+      </SubItem>
+      <Properties>
+        <Property>
+          <Name>TcTypeSystem</Name>
+        </Property>
+        <Property>
+          <Name>signature_flag</Name>
+          <Value>33554432</Value>
+        </Property>
+        <Property>
+          <Name>checksuperglobal</Name>
+        </Property>
+        <Property>
+          <Name>show</Name>
+        </Property>
+        <Property>
+          <Name>no-analysis</Name>
+        </Property>
+        <Property>
+          <Name>TcEventClass</Name>
+          <Value>LCLSGeneralEventClass</Value>
+        </Property>
+      </Properties>
+    </DataType>
   </DataTypes>
   <Modules>
-    <Module GUID="{D175205F-AF7A-4400-BB1A-38C938E0BF2D}" TcSmClass="TComPlcObjDef">
+    <Module GUID="{D175205F-AF7A-4400-BB1A-38C938E0BF2D}" TcSmClass="TComPlcObjDef" TargetPlatform="TwinCAT RT (x64)">
       <Name>lcls_twincat_optics_plc</Name>
       <CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
       <Licenses>
@@ -37931,7 +35573,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634679040</BitOffs>
+            <BitOffs>634679104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.bSTOEnable2</Name>
@@ -37943,7 +35585,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634679048</BitOffs>
+            <BitOffs>634679112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.stYupEnc</Name>
@@ -37956,7 +35598,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634679104</BitOffs>
+            <BitOffs>634679168</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.stYdwnEnc</Name>
@@ -37968,7 +35610,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634679232</BitOffs>
+            <BitOffs>634679296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.stXupEnc</Name>
@@ -37980,7 +35622,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634679360</BitOffs>
+            <BitOffs>634679424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.stXdwnEnc</Name>
@@ -37992,7 +35634,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634679488</BitOffs>
+            <BitOffs>634679552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.PEnc.Count</Name>
@@ -38005,7 +35647,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634680256</BitOffs>
+            <BitOffs>634680320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleY.gantry_diff_limit.SEnc.Count</Name>
@@ -38018,7 +35660,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634680384</BitOffs>
+            <BitOffs>634680448</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.PEnc.Count</Name>
@@ -38031,7 +35673,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634691008</BitOffs>
+            <BitOffs>634691072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender.fbRunHOMS.fbAutoCoupleX.gantry_diff_limit.SEnc.Count</Name>
@@ -38044,19 +35686,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634691136</BitOffs>
+            <BitOffs>634691200</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634702464</BitOffs>
+            <BitOffs>634702528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitForwardEnable</Name>
@@ -38065,21 +35707,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634710464</BitOffs>
+            <BitOffs>634710528</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bLimitBackwardEnable</Name>
@@ -38088,21 +35720,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634710472</BitOffs>
+            <BitOffs>634710536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHome</Name>
@@ -38111,21 +35733,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634710480</BitOffs>
+            <BitOffs>634710544</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bHardwareEnable</Name>
@@ -38148,7 +35760,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634710496</BitOffs>
+            <BitOffs>634710560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderULINT</Name>
@@ -38161,7 +35773,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634710528</BitOffs>
+            <BitOffs>634710592</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderUINT</Name>
@@ -38174,7 +35786,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634710592</BitOffs>
+            <BitOffs>634710656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.nRawEncoderINT</Name>
@@ -38187,19 +35799,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634710608</BitOffs>
+            <BitOffs>634710672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634727744</BitOffs>
+            <BitOffs>634727808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitForwardEnable</Name>
@@ -38208,21 +35820,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634735744</BitOffs>
+            <BitOffs>634735808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bLimitBackwardEnable</Name>
@@ -38231,21 +35833,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634735752</BitOffs>
+            <BitOffs>634735816</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHome</Name>
@@ -38254,21 +35846,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634735760</BitOffs>
+            <BitOffs>634735824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bHardwareEnable</Name>
@@ -38291,7 +35873,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634735776</BitOffs>
+            <BitOffs>634735840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderULINT</Name>
@@ -38304,7 +35886,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634735808</BitOffs>
+            <BitOffs>634735872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderUINT</Name>
@@ -38317,7 +35899,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634735872</BitOffs>
+            <BitOffs>634735936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.nRawEncoderINT</Name>
@@ -38330,19 +35912,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634735888</BitOffs>
+            <BitOffs>634735952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634753024</BitOffs>
+            <BitOffs>634753088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitForwardEnable</Name>
@@ -38351,21 +35933,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634761024</BitOffs>
+            <BitOffs>634761088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bLimitBackwardEnable</Name>
@@ -38374,21 +35946,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634761032</BitOffs>
+            <BitOffs>634761096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHome</Name>
@@ -38397,21 +35959,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634761040</BitOffs>
+            <BitOffs>634761104</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bHardwareEnable</Name>
@@ -38434,7 +35986,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634761056</BitOffs>
+            <BitOffs>634761120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderULINT</Name>
@@ -38447,7 +35999,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634761088</BitOffs>
+            <BitOffs>634761152</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderUINT</Name>
@@ -38460,7 +36012,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634761152</BitOffs>
+            <BitOffs>634761216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.nRawEncoderINT</Name>
@@ -38473,19 +36025,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634761168</BitOffs>
+            <BitOffs>634761232</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634778304</BitOffs>
+            <BitOffs>634778368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitForwardEnable</Name>
@@ -38494,21 +36046,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634786304</BitOffs>
+            <BitOffs>634786368</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bLimitBackwardEnable</Name>
@@ -38517,21 +36059,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634786312</BitOffs>
+            <BitOffs>634786376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHome</Name>
@@ -38540,21 +36072,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634786320</BitOffs>
+            <BitOffs>634786384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bHardwareEnable</Name>
@@ -38577,7 +36099,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634786336</BitOffs>
+            <BitOffs>634786400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderULINT</Name>
@@ -38590,7 +36112,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634786368</BitOffs>
+            <BitOffs>634786432</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderUINT</Name>
@@ -38603,7 +36125,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634786432</BitOffs>
+            <BitOffs>634786496</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.nRawEncoderINT</Name>
@@ -38616,19 +36138,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634786448</BitOffs>
+            <BitOffs>634786512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634803584</BitOffs>
+            <BitOffs>634803648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitForwardEnable</Name>
@@ -38637,21 +36159,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634811584</BitOffs>
+            <BitOffs>634811648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bLimitBackwardEnable</Name>
@@ -38660,21 +36172,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634811592</BitOffs>
+            <BitOffs>634811656</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHome</Name>
@@ -38683,21 +36185,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634811600</BitOffs>
+            <BitOffs>634811664</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bHardwareEnable</Name>
@@ -38720,7 +36212,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634811616</BitOffs>
+            <BitOffs>634811680</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderULINT</Name>
@@ -38733,7 +36225,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634811648</BitOffs>
+            <BitOffs>634811712</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderUINT</Name>
@@ -38746,7 +36238,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634811712</BitOffs>
+            <BitOffs>634811776</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.nRawEncoderINT</Name>
@@ -38759,19 +36251,19 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634811728</BitOffs>
+            <BitOffs>634811792</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634828864</BitOffs>
+            <BitOffs>634828928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitForwardEnable</Name>
@@ -38780,21 +36272,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitForwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if forward limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634836864</BitOffs>
+            <BitOffs>634836928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bLimitBackwardEnable</Name>
@@ -38803,21 +36285,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bLimitBackwardEnable
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC FALSE if reverse limit hit
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634836872</BitOffs>
+            <BitOffs>634836936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHome</Name>
@@ -38826,21 +36298,11 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bHome
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if at homing switch
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634836880</BitOffs>
+            <BitOffs>634836944</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bHardwareEnable</Name>
@@ -38863,7 +36325,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634836896</BitOffs>
+            <BitOffs>634836960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderULINT</Name>
@@ -38876,7 +36338,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634836928</BitOffs>
+            <BitOffs>634836992</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderUINT</Name>
@@ -38889,7 +36351,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634836992</BitOffs>
+            <BitOffs>634837056</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.nRawEncoderINT</Name>
@@ -38902,67 +36364,67 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634837008</BitOffs>
+            <BitOffs>634837072</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>634855936</BitOffs>
+            <BitOffs>634856000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635184448</BitOffs>
+            <BitOffs>635184512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635512960</BitOffs>
+            <BitOffs>635513024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>635841472</BitOffs>
+            <BitOffs>635841536</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m6.fbDriveVirtual.MasterAxis.NcToPlc</Name>
             <BitSize>2048</BitSize>
-            <BaseType GUID="{72F5AAAA-16DF-4ED3-8367-F6C8C3ADAE99}">NCTOPLC_AXIS_REF</BaseType>
+            <BaseType GUID="{25521FAA-EA5F-4C7F-8864-BBCCDACD2E98}">NCTOPLC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636169984</BitOffs>
+            <BitOffs>636170048</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TestStructs.TestPitch_LimitSwitches.diEncCnt</Name>
@@ -38975,7 +36437,7 @@ External Setpoint Generation:
                 <Value>Input</Value>
               </Property>
             </Properties>
-            <BitOffs>636499520</BitOffs>
+            <BitOffs>636499584</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -38986,14 +36448,14 @@ External Setpoint Generation:
           <Symbol>
             <Name>Main.M1.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
-            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634701440</BitOffs>
+            <BitOffs>634701504</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1.bBrakeRelease</Name>
@@ -39002,33 +36464,23 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634710488</BitOffs>
+            <BitOffs>634710552</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
-            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634726720</BitOffs>
+            <BitOffs>634726784</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2.bBrakeRelease</Name>
@@ -39037,33 +36489,23 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634735768</BitOffs>
+            <BitOffs>634735832</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
-            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634752000</BitOffs>
+            <BitOffs>634752064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3.bBrakeRelease</Name>
@@ -39072,33 +36514,23 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634761048</BitOffs>
+            <BitOffs>634761112</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
-            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634777280</BitOffs>
+            <BitOffs>634777344</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4.bBrakeRelease</Name>
@@ -39107,33 +36539,23 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634786328</BitOffs>
+            <BitOffs>634786392</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
-            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634802560</BitOffs>
+            <BitOffs>634802624</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5.bBrakeRelease</Name>
@@ -39142,33 +36564,23 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634811608</BitOffs>
+            <BitOffs>634811672</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.Axis.PlcToNc</Name>
             <BitSize>1024</BitSize>
-            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634827840</BitOffs>
+            <BitOffs>634827904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6.bBrakeRelease</Name>
@@ -39177,81 +36589,71 @@ External Setpoint Generation:
             <BaseType>BOOL</BaseType>
             <Properties>
               <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: PLC:bBrakeRelease
-        io: i
-        field: ZNAM FALSE
-        field: ONAM TRUE
-        field: DESC TRUE if brake released
-    </Value>
-              </Property>
-              <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634836888</BitOffs>
+            <BitOffs>634836952</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
-            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>634854912</BitOffs>
+            <BitOffs>634854976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
-            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635183424</BitOffs>
+            <BitOffs>635183488</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
-            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635511936</BitOffs>
+            <BitOffs>635512000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
-            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>635840448</BitOffs>
+            <BitOffs>635840512</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m6.fbDriveVirtual.MasterAxis.PlcToNc</Name>
             <BitSize>1024</BitSize>
-            <BaseType GUID="{63A84524-72E3-41C8-BEAB-4CCE44690A13}">PLCTONC_AXIS_REF</BaseType>
+            <BaseType GUID="{96B75FEB-2D84-43BE-A3EC-D9A681F27D52}">PLCTONC_AXIS_REF</BaseType>
             <Properties>
               <Property>
                 <Name>TcAddressType</Name>
                 <Value>Output</Value>
               </Property>
             </Properties>
-            <BitOffs>636168960</BitOffs>
+            <BitOffs>636169024</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -39423,7 +36825,7 @@ External Setpoint Generation:
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <Value>1</Value>
+              <DateTime>T#1ms</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -39438,7 +36840,7 @@ External Setpoint Generation:
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <Value>100</Value>
+              <DateTime>T#100ms</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -39453,7 +36855,7 @@ External Setpoint Generation:
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <Value>10000</Value>
+              <DateTime>T#10s</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -39468,7 +36870,7 @@ External Setpoint Generation:
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <Value>600000</Value>
+              <DateTime>T#10m</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -41537,7 +38939,7 @@ External Setpoint Generation:
             <BitSize>16</BitSize>
             <BaseType Namespace="Tc2_System">E_WATCHDOG_TIME_CONFIG</BaseType>
             <Default>
-              <Value>0</Value>
+              <EnumText>E_WATCHDOG_TIME_CONFIG.eWATCHDOG_TIME_DISABLED</EnumText>
             </Default>
             <Properties>
               <Property>
@@ -41552,7 +38954,7 @@ External Setpoint Generation:
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <Value>5000</Value>
+              <DateTime>5000</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -41647,7 +39049,7 @@ External Setpoint Generation:
             <BitSize>16</BitSize>
             <BaseType Namespace="Tc2_Utilities">E_HashPrefixTypes</BaseType>
             <Default>
-              <Value>0</Value>
+              <EnumText>E_HashPrefixTypes.HASHPREFIX_IEC</EnumText>
             </Default>
             <Properties>
               <Property>
@@ -41702,7 +39104,7 @@ External Setpoint Generation:
             <BitSize>16</BitSize>
             <BaseType Namespace="Tc2_Utilities">E_SBCSType</BaseType>
             <Default>
-              <Value>1</Value>
+              <EnumText>E_SBCSType.eSBCS_WesternEuropean</EnumText>
             </Default>
             <Properties>
               <Property>
@@ -41717,7 +39119,7 @@ External Setpoint Generation:
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Default>
-              <Value>0</Value>
+              <Bool>false</Bool>
             </Default>
             <Properties>
               <Property>
@@ -41747,7 +39149,7 @@ External Setpoint Generation:
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <Value>140</Value>
+              <DateTime>140</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -42076,7 +39478,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.tTimeout</Name>
-                <Value>0</Value>
+                <DateTime>0</DateTime>
               </SubItem>
               <SubItem>
                 <Name>.dwFlags</Name>
@@ -42458,7 +39860,7 @@ External Setpoint Generation:
             <Default>
               <SubItem>
                 <Name>.eType</Name>
-                <Value>0</Value>
+                <EnumText>E_ArgType.ARGTYPE_UNKNOWN</EnumText>
               </SubItem>
               <SubItem>
                 <Name>.cbLen</Name>
@@ -43359,7 +40761,7 @@ External Setpoint Generation:
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Default>
-              <Value>1</Value>
+              <Bool>true</Bool>
             </Default>
             <Properties>
               <Property>
@@ -43458,7 +40860,7 @@ External Setpoint Generation:
             <BitSize>16</BitSize>
             <BaseType GUID="{B57D3F4A-0836-49B0-81C3-BED5F4817EC9}">TcEventSeverity</BaseType>
             <Default>
-              <Value>0</Value>
+              <EnumText>TcEventSeverity.Verbose</EnumText>
             </Default>
             <Properties>
               <Property>
@@ -43709,7 +41111,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.eSeverity</Name>
-                <Value>0</Value>
+                <EnumText>Global_Constants.EMPTY_SEVERITY</EnumText>
               </SubItem>
             </Default>
             <Properties>
@@ -43949,7 +41351,7 @@ External Setpoint Generation:
             <BitSize>8</BitSize>
             <BaseType>BOOL</BaseType>
             <Default>
-              <Value>0</Value>
+              <Bool>false</Bool>
             </Default>
             <Properties>
               <Property>
@@ -44051,7 +41453,7 @@ External Setpoint Generation:
             <BitSize>32</BitSize>
             <BaseType>TIME</BaseType>
             <Default>
-              <Value>0</Value>
+              <DateTime>0</DateTime>
             </Default>
             <Properties>
               <Property>
@@ -44077,13 +41479,10 @@ External Setpoint Generation:
             <BitOffs>3374304</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
-            <Comment> Maximum # of attenuators in the PMPS</Comment>
+            <Name>MOTION_GVL.nMaxStateMotorCount</Name>
+            <Comment> Debug, records the highest number of motors used in an ND states block in the PLC. Can be used to limit MotionConstants.MAX_STATE_MOTORS to save on memory usage and PV count.</Comment>
             <BitSize>16</BitSize>
             <BaseType>UINT</BaseType>
-            <Default>
-              <Value>16</Value>
-            </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
@@ -44208,7 +41607,39 @@ External Setpoint Generation:
             <BitOffs>633606080</BitOffs>
           </Symbol>
           <Symbol>
+            <Name>MOTION_GVL.nMaxStates</Name>
+            <Comment> Debug, records the highest state count in the PLC. Can be used to limit GeneralConstants.MAX_STATES to save on memory usage and PV count.</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633606368</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>MotionConstants.MAX_STATE_MOTORS</Name>
+            <Comment>
+    Arbitary cap on multidimensional states to simplify statements for the compiler.
+    This is reconfigurable at the project level and should be set to the highest number of motors used in a states block.
+    If you are not sure how many motors are used per state block, check MOTION_GVL.nMaxStateMotorCount
+    </Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>3</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>633606384</BitOffs>
+          </Symbol>
+          <Symbol>
             <Name>MOTION_GVL.fbPmpsFileReader</Name>
+            <Comment> Global file reader instance, used in fbStandardPMPSDB</Comment>
             <BitSize>935616</BitSize>
             <BaseType Namespace="PMPS">FB_JsonFileToJsonDoc</BaseType>
             <Properties>
@@ -44220,6 +41651,7 @@ External Setpoint Generation:
           </Symbol>
           <Symbol>
             <Name>MOTION_GVL.fbStandardPMPSDB</Name>
+            <Comment> Global DB handler, Must be called in PLC project to use the PMPS DB for a motion project</Comment>
             <BitSize>30144</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_Standard_PMPSDB</BaseType>
             <Properties>
@@ -44326,7 +41758,21 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634576800</BitOffs>
+            <BitOffs>634576896</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
+            <BitSize>32</BitSize>
+            <BaseType>UDINT</BaseType>
+            <Default>
+              <Value>300</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634576928</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.VISIBLE_TEST_VELOCITY</Name>
@@ -44340,7 +41786,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634576896</BitOffs>
+            <BitOffs>634576960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.FAST_TEST_VELOCITY</Name>
@@ -44348,20 +41794,6 @@ External Setpoint Generation:
             <BaseType>LREAL</BaseType>
             <Default>
               <Value>100</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634576960</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.MAX_DEVICE_STATES</Name>
-            <BitSize>32</BitSize>
-            <BaseType>UDINT</BaseType>
-            <Default>
-              <Value>300</Value>
             </Default>
             <Properties>
               <Property>
@@ -44383,7 +41815,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634577056</BitOffs>
+            <BitOffs>634577088</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.AUX_ATTENUATORS</Name>
+            <Comment> Maximum # of attenuators in the PMPS</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>16</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634577120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_VETO_DEVICES</Name>
@@ -44397,7 +41844,68 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634577088</BitOffs>
+            <BitOffs>634577136</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.stAttenuators</Name>
+            <BitSize>64</BitSize>
+            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
+            <Default>
+              <SubItem>
+                <Name>.nTran</Name>
+                <Value>1</Value>
+              </SubItem>
+              <SubItem>
+                <Name>.xAttOK</Name>
+                <Value>1</Value>
+              </SubItem>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634577152</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cstFullBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)FullBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC Full beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634577216</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.cst0RateBeam</Name>
+            <BitSize>1760</BitSize>
+            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
+            <Properties>
+              <Property>
+                <Name>pytmc</Name>
+                <Value>
+        pv: @(PREFIX)0RateBeamCnst
+		io: i
+        archive: 1Hz monitor
+        field: DESC 0-rate beam constant
+    </Value>
+              </Property>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634578976</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.cnMaxStateArrayLen</Name>
@@ -44422,68 +41930,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634577104</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.stAttenuators</Name>
-            <BitSize>64</BitSize>
-            <BaseType Namespace="PMPS">ST_PMPS_Attenuator</BaseType>
-            <Default>
-              <SubItem>
-                <Name>.nTran</Name>
-                <Value>1</Value>
-              </SubItem>
-              <SubItem>
-                <Name>.xAttOK</Name>
-                <Value>1</Value>
-              </SubItem>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634577120</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cstFullBeam</Name>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)FullBeamCnst
-		io: i
-        archive: 1Hz monitor
-        field: DESC Full beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634577184</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.cst0RateBeam</Name>
-            <BitSize>1760</BitSize>
-            <BaseType Namespace="PMPS">ST_BeamParams</BaseType>
-            <Properties>
-              <Property>
-                <Name>pytmc</Name>
-                <Value>
-        pv: @(PREFIX)0RateBeamCnst
-		io: i
-        archive: 1Hz monitor
-        field: DESC 0-rate beam constant
-    </Value>
-              </Property>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634578944</BitOffs>
+            <BitOffs>634580736</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.MAX_APERTURES</Name>
@@ -44498,21 +41945,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634580704</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_GVL.g_cBoundaries</Name>
-            <BitSize>16</BitSize>
-            <BaseType>INT</BaseType>
-            <Default>
-              <Value>31</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634580720</BitOffs>
+            <BitOffs>634580752</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.DUMMY_AUX_ATT_ARRAY</Name>
@@ -44531,7 +41964,36 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634580736</BitOffs>
+            <BitOffs>634580768</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_GVL.g_cBoundaries</Name>
+            <BitSize>16</BitSize>
+            <BaseType>INT</BaseType>
+            <Default>
+              <Value>31</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634581792</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
+            <Comment> Max fast faults for an FFO</Comment>
+            <BitSize>16</BitSize>
+            <BaseType>UINT</BaseType>
+            <Default>
+              <Value>50</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634581808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.reVHyst</Name>
@@ -44558,7 +42020,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634581760</BitOffs>
+            <BitOffs>634581824</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesL</Name>
@@ -44713,7 +42175,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634581792</BitOffs>
+            <BitOffs>634581856</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.g_areVBoundariesK</Name>
@@ -44868,37 +42330,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634582816</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>PMPS_PARAM.MAX_FAST_FAULTS</Name>
-            <Comment> Max fast faults for an FFO</Comment>
-            <BitSize>16</BitSize>
-            <BaseType>UINT</BaseType>
-            <Default>
-              <Value>50</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634583840</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bLittleEndian</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>634583864</BitOffs>
+            <BitOffs>634582880</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.MAX_ASSERTIONS</Name>
@@ -44913,7 +42345,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634583872</BitOffs>
+            <BitOffs>634583904</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_PARAM.TRANS_MARGIN</Name>
@@ -44928,7 +42360,22 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634583904</BitOffs>
+            <BitOffs>634583936</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>GVL_Constants.cPiezoRange</Name>
+            <Comment> From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are</Comment>
+            <BitSize>32</BitSize>
+            <BaseType>REAL</BaseType>
+            <Default>
+              <Value>60</Value>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634583968</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_TOOLS.fbJson</Name>
@@ -44939,7 +42386,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634583936</BitOffs>
+            <BitOffs>634584000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_MC2</Name>
@@ -44979,22 +42426,52 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634584320</BitOffs>
+            <BitOffs>634584384</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>GVL_Constants.cPiezoRange</Name>
-            <Comment> From Old HOMS_FEE Project, 90 um of piezo stroke, unsure what these units are</Comment>
-            <BitSize>32</BitSize>
-            <BaseType>REAL</BaseType>
+            <Name>Constants.bLittleEndian</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
             <Default>
-              <Value>60</Value>
+              <Bool>true</Bool>
             </Default>
             <Properties>
               <Property>
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634584608</BitOffs>
+            <BitOffs>634584680</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bSimulationMode</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634584688</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bFPUSupport</Name>
+            <Comment> Does the target support multiple cores?</Comment>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>true</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>634584696</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.TcMcGlobal</Name>
@@ -45005,7 +42482,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634584640</BitOffs>
+            <BitOffs>634584704</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_HOME_POSITION</Name>
@@ -45019,7 +42496,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634591744</BitOffs>
+            <BitOffs>634591808</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Variables.DEFAULT_BACKLASHVALUE</Name>
@@ -45033,7 +42510,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634591808</BitOffs>
+            <BitOffs>634591872</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_Math</Name>
@@ -45069,7 +42546,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634591872</BitOffs>
+            <BitOffs>634591936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Global_Version.stLibVersion_Tc2_ControllerToolbox</Name>
@@ -45109,24 +42586,24 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634592160</BitOffs>
+            <BitOffs>634592224</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.TESTWithBender</Name>
             <Comment>
-	// Test Pitch Control
-	fbPitchControl : FB_PitchControl;
-	TestPitch : HOMS_PitchMechanism := (ReqPosLimHi:=2000,
-		                                ReqPosLimLo:=-2000,
-		                                diEncPosLimHi:=10768330,
-		                                diEncPosLimLo:=8141680);
-	M1 : DUT_MotionStage;
-	bPitchDone : BOOL;
-	
+    // Test Pitch Control
+    fbPitchControl : FB_PitchControl;
+    TestPitch : HOMS_PitchMechanism := (ReqPosLimHi:=2000,
+                                        ReqPosLimLo:=-2000,
+                                        diEncPosLimHi:=10768330,
+                                        diEncPosLimLo:=8141680);
+    M1 : DUT_MotionStage;
+    bPitchDone : BOOL;
+    
  Test Bender vs No Bender</Comment>
             <BitSize>23552</BitSize>
             <BaseType>DUT_HOMS</BaseType>
-            <BitOffs>634677824</BitOffs>
+            <BitOffs>634677888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M1</Name>
@@ -45135,10 +42612,10 @@ External Setpoint Generation:
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <Value>0</Value>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
             </Default>
-            <BitOffs>634701376</BitOffs>
+            <BitOffs>634701440</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M2</Name>
@@ -45147,10 +42624,10 @@ External Setpoint Generation:
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <Value>0</Value>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
             </Default>
-            <BitOffs>634726656</BitOffs>
+            <BitOffs>634726720</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M3</Name>
@@ -45159,10 +42636,10 @@ External Setpoint Generation:
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <Value>0</Value>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
             </Default>
-            <BitOffs>634751936</BitOffs>
+            <BitOffs>634752000</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M4</Name>
@@ -45171,10 +42648,10 @@ External Setpoint Generation:
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <Value>0</Value>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
             </Default>
-            <BitOffs>634777216</BitOffs>
+            <BitOffs>634777280</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M5</Name>
@@ -45183,10 +42660,10 @@ External Setpoint Generation:
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <Value>0</Value>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
             </Default>
-            <BitOffs>634802496</BitOffs>
+            <BitOffs>634802560</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.M6</Name>
@@ -45195,46 +42672,46 @@ External Setpoint Generation:
             <Default>
               <SubItem>
                 <Name>.nEnableMode</Name>
-                <Value>0</Value>
+                <EnumText>E_StageEnableMode.ALWAYS</EnumText>
               </SubItem>
             </Default>
-            <BitOffs>634827776</BitOffs>
+            <BitOffs>634827840</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbBender</Name>
             <BitSize>256</BitSize>
             <BaseType>FB_Bender</BaseType>
-            <BitOffs>634853056</BitOffs>
+            <BitOffs>634853120</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m1</Name>
             <BitSize>328512</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>634853312</BitOffs>
+            <BitOffs>634853376</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m2</Name>
             <BitSize>328512</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>635181824</BitOffs>
+            <BitOffs>635181888</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m3</Name>
             <BitSize>328512</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>635510336</BitOffs>
+            <BitOffs>635510400</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m4</Name>
             <BitSize>328512</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>635838848</BitOffs>
+            <BitOffs>635838912</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Main.fbMotionStage_m6</Name>
             <BitSize>328512</BitSize>
             <BaseType Namespace="lcls_twincat_motion">FB_MotionStage</BaseType>
-            <BitOffs>636167360</BitOffs>
+            <BitOffs>636167424</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.nGANTRY_TOLERANCE_NM_DEFAULT</Name>
@@ -45249,7 +42726,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636496896</BitOffs>
+            <BitOffs>636496960</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMaxVoltage</Name>
@@ -45264,7 +42741,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636496960</BitOffs>
+            <BitOffs>636497024</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_Constants.cPiezoMinVoltage</Name>
@@ -45279,7 +42756,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636497024</BitOffs>
+            <BitOffs>636497088</BitOffs>
           </Symbol>
           <Symbol>
             <Name>GVL_TestStructs.TestPitch_LimitSwitches</Name>
@@ -45308,10 +42785,10 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636497088</BitOffs>
+            <BitOffs>636497152</BitOffs>
           </Symbol>
           <Symbol>
-            <Name>Global_Version.stLibVersion_lcls_twincat_optics</Name>
+            <Name>Global_Version.stLibVersion_lcls_twincat_optics_nrw</Name>
             <BitSize>288</BitSize>
             <BaseType GUID="{6F5942ED-BFA1-497D-8225-23C6DAAD0A09}">ST_LibVersion</BaseType>
             <Default>
@@ -45321,11 +42798,11 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.iMinor</Name>
-                <Value>6</Value>
+                <Value>0</Value>
               </SubItem>
               <SubItem>
                 <Name>.iBuild</Name>
-                <Value>1</Value>
+                <Value>0</Value>
               </SubItem>
               <SubItem>
                 <Name>.iRevision</Name>
@@ -45337,7 +42814,7 @@ External Setpoint Generation:
               </SubItem>
               <SubItem>
                 <Name>.sVersion</Name>
-                <String>0.6.1</String>
+                <String>0.0.0</String>
               </SubItem>
             </Default>
             <Properties>
@@ -45348,7 +42825,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636499584</BitOffs>
+            <BitOffs>636499648</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersion</Name>
@@ -45378,7 +42855,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636499872</BitOffs>
+            <BitOffs>636499936</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersion</Name>
@@ -45408,37 +42885,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636499936</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bSimulationMode</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
             <BitOffs>636500000</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bFPUSupport</Name>
-            <Comment> Does the target support multiple cores?</Comment>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>1</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>636500008</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nRegisterSize</Name>
@@ -45453,7 +42900,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636500016</BitOffs>
+            <BitOffs>636500064</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.nPackMode</Name>
@@ -45468,21 +42915,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636500032</BitOffs>
-          </Symbol>
-          <Symbol>
-            <Name>Constants.bMulticoreSupport</Name>
-            <BitSize>8</BitSize>
-            <BaseType>BOOL</BaseType>
-            <Default>
-              <Value>0</Value>
-            </Default>
-            <Properties>
-              <Property>
-                <Name>TcVarGlobal</Name>
-              </Property>
-            </Properties>
-            <BitOffs>636500048</BitOffs>
+            <BitOffs>636500080</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.RuntimeVersionNumeric</Name>
@@ -45497,7 +42930,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636500064</BitOffs>
+            <BitOffs>636500096</BitOffs>
           </Symbol>
           <Symbol>
             <Name>Constants.CompilerVersionNumeric</Name>
@@ -45512,7 +42945,21 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636500096</BitOffs>
+            <BitOffs>636500128</BitOffs>
+          </Symbol>
+          <Symbol>
+            <Name>Constants.bMulticoreSupport</Name>
+            <BitSize>8</BitSize>
+            <BaseType>BOOL</BaseType>
+            <Default>
+              <Bool>false</Bool>
+            </Default>
+            <Properties>
+              <Property>
+                <Name>TcVarGlobal</Name>
+              </Property>
+            </Properties>
+            <BitOffs>636500160</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_LicenseInfoVarList._LicenseInfo</Name>
@@ -45581,7 +43028,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636500128</BitOffs>
+            <BitOffs>636500192</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskPouOid_PlcTask</Name>
@@ -45595,7 +43042,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636501152</BitOffs>
+            <BitOffs>636501216</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._AppInfo</Name>
@@ -45609,7 +43056,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636501184</BitOffs>
+            <BitOffs>636501248</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskInfo</Name>
@@ -45627,7 +43074,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636503232</BitOffs>
+            <BitOffs>636503296</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList._TaskOid_PlcTask</Name>
@@ -45641,7 +43088,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636504256</BitOffs>
+            <BitOffs>636504320</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TwinCAT_SystemInfoVarList.__PlcTask</Name>
@@ -45662,13 +43109,13 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636504320</BitOffs>
+            <BitOffs>636504384</BitOffs>
           </Symbol>
           <Symbol>
             <Name>TC_EVENTS.LCLSGeneralEventClass</Name>
             <Comment> ST_LCLSGeneralEventClass</Comment>
             <BitSize>960</BitSize>
-            <BaseType GUID="{97CF8247-B59C-4E2C-B4B0-7350D0471457}">ST_LCLSGeneralEventClass</BaseType>
+            <BaseType>ST_LCLSGeneralEventClass</BaseType>
             <Properties>
               <Property>
                 <Name>tc_no_symbol</Name>
@@ -45688,7 +43135,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>636555904</BitOffs>
+            <BitOffs>636556096</BitOffs>
           </Symbol>
         </DataArea>
         <DataArea>
@@ -45713,7 +43160,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>633606368</BitOffs>
+            <BitOffs>634576768</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.AccumulatedFF</Name>
@@ -45732,7 +43179,7 @@ External Setpoint Generation:
                 <Name>TcVarGlobal</Name>
               </Property>
             </Properties>
-            <BitOffs>634576768</BitOffs>
+            <BitOffs>634576800</BitOffs>
           </Symbol>
           <Symbol>
             <Name>PMPS_GVL.BP_jsonDoc</Name>
@@ -45760,7 +43207,7 @@ External Setpoint Generation:
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2023-06-21T11:16:31</Value>
+          <Value>2024-01-24T14:57:25</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Pinned build version to 4024.35
- Made a new Fast Fault for Beam parameters not loaded.
- changes to `lcls-twincat-optics/lcls_twincat_optics_plc/POUs/Helpers/FB_MirrorTwoCoatingProtection.TcPOU` the rest are pre commit changes.
- updated `FB_MirrorTwoCoatingProtection` to be backward compatible. That is, pmps states need not be implemented in JSON database file for this function block to work. 
- add `bUsePmpsDb` flag.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Fast Fault descriptions for coating faults were showing up as beam parameters not loaded when in fact they were. Fast Fault descriptions only run once during set up.
- 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- running on lcls-plc-tmo-optics

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
